### PR TITLE
Feature/multi app auto launch

### DIFF
--- a/src/screens/KioskScreen.tsx
+++ b/src/screens/KioskScreen.tsx
@@ -1651,9 +1651,7 @@ const KioskScreen: React.FC<KioskScreenProps> = ({ navigation }) => {
           console.log('[KioskScreen] Launching external app:', savedExternalAppPackage);
           await launchExternalApp(savedExternalAppPackage, savedReturnTapCount, savedReturnTapTimeout, savedReturnMode, savedReturnButtonPosition);
         } else if (savedExternalAppMode === 'multi') {
-          // Multi-app mode: don't auto-launch, the grid will be displayed by ExternalAppOverlay
-          console.log('[KioskScreen] Multi-app mode: showing app grid (no auto-launch)');
-          // Still sync overlay settings for when user launches an app from grid
+          // Multi-app mode: sync overlay settings for when user launches an app from grid
           const savedTestMode = bool(K.EXTERNAL_APP_TEST_MODE, true);
           const savedBackBtnMode = str(K.BACK_BUTTON_MODE) || 'test';
           try {
@@ -1661,6 +1659,24 @@ const KioskScreen: React.FC<KioskScreenProps> = ({ navigation }) => {
             await OverlayServiceModule.setBackButtonMode(savedBackBtnMode);
           } catch (e) {
             console.warn('[KioskScreen] Failed to sync overlay settings for multi-app:', e);
+          }
+
+          // If only one app is visible on the home screen, skip the grid and automatically launch it
+          const homeScreenApps = savedManagedApps.filter(app => app.showOnHomeScreen);
+          if (homeScreenApps.length === 1) {
+            const soleApp = homeScreenApps[0];
+            console.log('[KioskScreen] Multi-app mode with single home screen app - launching:', soleApp.packageName);
+            const blockBeforeLaunch = await KioskModule.shouldBlockAutoRelaunch();
+            if (blockBeforeLaunch || isNavigatingToPinRef.current) {
+              console.log('[KioskScreen] Skipping auto-launch (blockAutoRelaunch=' + blockBeforeLaunch + ', navigatingToPin=' + isNavigatingToPinRef.current + ')');
+              if (blockBeforeLaunch) {
+                await KioskModule.clearBlockAutoRelaunch();
+              }
+              return;
+            }
+            await launchExternalApp(soleApp.packageName, savedReturnTapCount, savedReturnTapTimeout, savedReturnMode, savedReturnButtonPosition);
+          } else {
+            console.log('[KioskScreen] Multi-app mode: showing app grid (' + homeScreenApps.length + ' apps)');
           }
         }
       } else {
@@ -2109,8 +2125,14 @@ const KioskScreen: React.FC<KioskScreenProps> = ({ navigation }) => {
   const handleReturnToExternalApp = async (): Promise<void> => {
     // Read fresh mode from ref (most up-to-date)
     if (externalAppModeRef.current === 'multi') {
-      // Multi-app mode: return to the app grid
-      setIsAppLaunched(false);
+      // Multi-app mode: if only one home screen app, re-launch it directly
+      const homeScreenApps = managedApps.filter(app => app.showOnHomeScreen);
+      if (homeScreenApps.length === 1) {
+        await launchExternalApp(homeScreenApps[0].packageName);
+      } else {
+        // Multiple apps: return to the app grid
+        setIsAppLaunched(false);
+      }
     } else {
       // Single-app mode: read current package from storage (avoid stale state)
       const currentPkg = await StorageService.getExternalAppPackage();


### PR DESCRIPTION
## 📝 Description

When multi-app mode is configured but only a single app is set to show on the home screen, the kiosk now behaves like single-app mode by automatically launching that app instead of displaying the app grid with just one option. If multiple apps are visible on the home screen, the existing app grid behavior is the same.

## 🔧 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🎨 UI/UX improvement

## ✅ Testing

Please describe the tests you ran to verify your changes:

- [x] Tested on real Android device
- [x] Tested in Device Owner mode
- [x] No regressions found

**Device(s) tested:**
- Device: Samsung Tab Active 5
- Android version: Android 14

## 📋 Checklist

- [x] My code follows the project's code style
- [x] I have commented my code where necessary
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have tested on a real device (not just emulator)
- [x] All existing tests still pass

## 🔗 Related Issues/PRs

- Related to #112 

