### PR TITLE
Fix OverlayService dying after 5-tap return gesture

### DIFF
--- a/android/app/src/main/java/com/freekiosk/MainActivity.kt
+++ b/android/app/src/main/java/com/freekiosk/MainActivity.kt
@@ -404,6 +404,15 @@ class MainActivity : ReactActivity() {
       DebugLog.d("MainActivity", "Voluntary return detected (5-tap), will navigate to PIN: $navigateToPin")
     }
 
+    // Fix #overlay-restart: OverlayService.returnToFreeKiosk() sets blockAutoRelaunch=true
+    // BEFORE calling task.moveToFront(), which fires onResume() with the OLD intent
+    // (no voluntaryReturn flag yet). Without this check, onResume() takes the fast path
+    // and relaunches 24Six without starting OverlayService.
+    if (blockAutoRelaunch && !isVoluntaryReturn) {
+      isVoluntaryReturn = true
+      DebugLog.d("MainActivity", "blockAutoRelaunch=true — treating as voluntary return to prevent fast-path relaunch")
+    }
+
     // Fix #106: In external app mode, only stop the overlay on VOLUNTARY returns
     // (e.g. admin 5-tap to access settings). On involuntary returns (system brought
     // FreeKiosk back), keep the overlay running so the foreground monitor can
@@ -437,6 +446,9 @@ class MainActivity : ReactActivity() {
           val launchIntent = packageManager.getLaunchIntentForPackage(targetPkg)
           if (launchIntent != null) {
             launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            // Restart OverlayService BEFORE launching 24Six so the button is present
+            // when the external app comes to the foreground.
+            startOverlayServiceFromNative(targetPkg)
             startActivity(launchIntent)
             // Move FreeKiosk to background so external app stays visible
             Handler(Looper.getMainLooper()).postDelayed({ moveTaskToBack(true) }, 300)
@@ -506,6 +518,46 @@ class MainActivity : ReactActivity() {
       DebugLog.d("MainActivity", "Stopped OverlayService")
     } catch (e: Exception) {
       DebugLog.errorProduction("MainActivity", "Error stopping OverlayService: ${e.message}")
+    }
+  }
+
+  /**
+   * Start OverlayService from native code, reading parameters from AsyncStorage.
+   * Called from onResume() fast path (involuntary return) to ensure the overlay
+   * button is present when the external app is relaunched.
+   *
+   * This is needed because the JS layer (KioskScreen/PinScreen) cannot start the
+   * service reliably from a background context, and the fast path bypasses JS entirely.
+   */
+  private fun startOverlayServiceFromNative(lockedPackage: String) {
+    try {
+      if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+        if (!android.provider.Settings.canDrawOverlays(this)) {
+          DebugLog.d("MainActivity", "Overlay permission not granted, skipping startOverlayServiceFromNative")
+          return
+        }
+      }
+
+      val tapCount = getAsyncStorageValue("@kiosk_return_tap_count", "5").toIntOrNull() ?: 5
+      val tapTimeout = getAsyncStorageValue("@kiosk_return_tap_timeout", "1500").toIntOrNull() ?: 1500
+      val returnMode = getAsyncStorageValue("@kiosk_return_mode", "button")
+      val buttonPosition = getAsyncStorageValue("@kiosk_return_button_position", "bottom-right")
+      val autoRelaunch = getAsyncStorageValue("@kiosk_auto_relaunch_app", "true") == "true"
+      val nfcEnabled = getAsyncStorageValue("@kiosk_allow_notifications", "false") == "true"
+
+      val serviceIntent = Intent(this, OverlayService::class.java)
+      serviceIntent.putExtra("REQUIRED_TAPS", tapCount.coerceIn(2, 20))
+      serviceIntent.putExtra("TAP_TIMEOUT", tapTimeout.coerceIn(500, 5000).toLong())
+      serviceIntent.putExtra("RETURN_MODE", returnMode)
+      serviceIntent.putExtra("BUTTON_POSITION", buttonPosition)
+      serviceIntent.putExtra("LOCKED_PACKAGE", lockedPackage)
+      serviceIntent.putExtra("AUTO_RELAUNCH", autoRelaunch)
+      serviceIntent.putExtra("NFC_ENABLED", nfcEnabled)
+
+      startService(serviceIntent)
+      DebugLog.d("MainActivity", "startOverlayServiceFromNative: taps=$tapCount timeout=${tapTimeout}ms mode=$returnMode pos=$buttonPosition pkg=$lockedPackage autoRelaunch=$autoRelaunch")
+    } catch (e: Exception) {
+      DebugLog.errorProduction("MainActivity", "Failed to start OverlayService from native: ${e.message}")
     }
   }
 

--- a/src/screens/KioskScreen.tsx
+++ b/src/screens/KioskScreen.tsx
@@ -777,12 +777,13 @@ const KioskScreen: React.FC<KioskScreenProps> = ({ navigation }) => {
         await AsyncStorage.getItem('__force_init__');
       } catch (e) {}
       
-      await loadSettings();
-      
-      // Clear navigating-to-pin guard AFTER loadSettings completes.
-      // This ensures the guard is available during loadSettings execution
-      // to prevent external app relaunch during 5-tap→PIN navigation.
+      // Clear navigating-to-pin guard BEFORE loadSettings so that returning from
+      // PIN/Settings causes loadSettings to proceed with the external app launch.
+      // The guard's purpose (preventing a duplicate launch mid-5-tap-flow) is already
+      // served: by the time KioskScreen gains focus again, the PIN flow is complete.
       isNavigatingToPinRef.current = false;
+
+      await loadSettings();
       
       // Reload blocking overlays to ensure they stay active when returning from settings
       try {


### PR DESCRIPTION
## Summary

Fixes #136 — after the user taps the return button 5 times (or uses the back button from the PIN screen), the OverlayService was being killed and never restarted, leaving the external app running with no way to return to settings.

Three bugs combined to cause this:

**Bug 1 — `onResume()` fast-path race (`MainActivity.kt`)**

`OverlayService.returnToFreeKiosk()` calls `task.moveToFront()` to bring FreeKiosk to the foreground, then fires a new `Intent` with `voluntaryReturn=true` via `startActivity()`. The problem: `task.moveToFront()` triggers `onResume()` *immediately* with the **old** intent (no `voluntaryReturn` flag), while the new intent only arrives later via `onNewIntent()`. So `onResume()` evaluated `isVoluntaryReturn=false` and took the fast path — relaunching the external app without starting OverlayService.

Fix: `returnToFreeKiosk()` already sets `MainActivity.blockAutoRelaunch = true` before calling `moveToFront()`. We now check this flag in `onResume()` and treat it as a voluntary return, which skips the fast path.

**Bug 2 — No OverlayService restart on involuntary returns (`MainActivity.kt`)**

The native fast path (involuntary return → relaunch external app directly from `onResume()`) never restarted OverlayService. Any time the system brought FreeKiosk to the foreground unexpectedly, the external app would be relaunched without an overlay button.

Fix: Added `startOverlayServiceFromNative()`, which reads all overlay parameters (tap count, timeout, return mode, button position, auto-relaunch, locked package) directly from AsyncStorage's SQLite database and starts OverlayService before `startActivity()`. This is called inside the fast path just before launching the external app.

**Bug 3 — `isNavigatingToPinRef` stuck `true` (`KioskScreen.tsx`)**

When the 5-tap event fires, `KioskScreen` sets `isNavigatingToPinRef.current = true` and navigates away to `PinScreen`. KioskScreen never regains focus during the PIN flow, so the ref is never cleared. When the user later navigates back to `KioskScreen` (after completing the PIN or pressing Back), the focus listener runs `loadSettings()` — but `loadSettings()` sees `isNavigatingToPinRef=true` and skips the external app launch entirely (this guard exists to prevent a race during the initial 5-tap navigation).

Fix: Clear `isNavigatingToPinRef.current = false` **before** calling `loadSettings()` in the focus listener instead of after. By the time `KioskScreen` regains focus, the PIN flow is already complete, so the guard's original purpose (preventing a duplicate launch mid-navigation) is already served.

## Test plan

- [ ] Boot device → FreeKiosk loads with overlay button visible on external app
- [ ] Tap overlay button 5 times → navigates to PIN screen
- [ ] Enter PIN → reach Settings, make a change, save → returns to external app **with overlay button still present**
- [ ] Tap overlay button 5 times again → PIN screen reachable again (not stuck)
- [ ] Press "Back to Kiosk" from PIN screen → returns to external app **with overlay button still present**
- [ ] Verify that involuntary returns (e.g. pressing Home, system brings FreeKiosk forward) still relaunch the external app with overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)