### PR TITLE
Add MODIFY_AUDIO_SETTINGS permission for WebRTC microphone

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,11 @@
         tools:ignore="ProtectedPermissions" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <!-- Required by Chromium WebView for WebRTC audio capture: getUserMedia() relies on
+         AudioManager.setMode(MODE_IN_COMMUNICATION) which needs MODIFY_AUDIO_SETTINGS.
+         Without it, audio_manager_android.cc logs "Unable to select communication device"
+         and the JS side receives NotReadableError ("Could not start audio source"). -->
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />


### PR DESCRIPTION
## 📝 Description

Adds the `MODIFY_AUDIO_SETTINGS` permission to the AndroidManifest. Without it, any web page loaded in the FreeKiosk WebView that calls `navigator.mediaDevices.getUserMedia({audio: true})` fails with `NotReadableError: Could not start audio source`, even when `RECORD_AUDIO` is granted at runtime and the page is served over HTTPS.

### Root cause

Chromium's WebRTC audio capture path on Android (`media/audio/android/audio_manager_android.cc`) calls `AudioManager.setMode(MODE_IN_COMMUNICATION)` to select the communication audio device. That call requires `MODIFY_AUDIO_SETTINGS`. When missing, Chromium logs:

W cr_media: Requires MODIFY_AUDIO_SETTINGS and RECORD_AUDIO.
No audio device will be available for recording
E chromium: [ERROR:media/audio/android/audio_manager_android.cc:876]
Unable to select communication device


The capture path aborts and JS receives `NotReadableError`.

### Use case

SIP / WebRTC intercom panels (sip.js, JsSIP, etc.) running inside FreeKiosk WebView — common for door-station and apartment-kiosk setups.

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## ✅ Testing

- [x] Tested on real Android device

**Device(s) tested:**
- Device: Lenovo Yoga Tab Plus 11 (TB710FU)
- Android version: 16
- WebView version: 147.0.7727.55
- FreeKiosk version: 1.2.18

### Reproduction (before fix)

1. FreeKiosk 1.2.18 installed on the device above.
2. Push URL: `https://webrtc.github.io/samples/src/content/getusermedia/audio/`
3. Page renders error: `navigator.MediaDevices.getUserMedia error: Could not start audio source NotReadableError`
4. `adb logcat | grep cr_media` shows the warnings above.

### Cross-check

The same frontend, when hosted by a separate APK that declares `MODIFY_AUDIO_SETTINGS` (verified via `dumpsys package`), works correctly on a Sony Xperia (Android 14). Identical WebView code path, identical RECORD_AUDIO grant state — the manifest permission is the only delta between working and failing hosts.

## 📋 Checklist

- [x] My code follows the project's code style
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have tested on a real device (not just emulator)

## 📝 Additional Notes

`MODIFY_AUDIO_SETTINGS` is a normal-protection-level permission, auto-granted at install time, no runtime prompt and no Device Owner provisioning change required. The diff is one `<uses-permission>` line plus an inline comment explaining why.