### PR TITLE
feat(tts): add voice enumeration and selection for Web Speech API pol…

### DIFF
--- a/android/app/src/main/java/com/freekiosk/api/HttpServerModule.kt
+++ b/android/app/src/main/java/com/freekiosk/api/HttpServerModule.kt
@@ -113,6 +113,7 @@ class HttpServerModule(private val reactContext: ReactApplicationContext) :
     // Text-to-Speech
     private var tts: TextToSpeech? = null
     private var ttsReady: Boolean = false
+    private var ttsVoicesCache: List<Map<String, String>> = emptyList()
 
     init {
         initSensors()
@@ -132,6 +133,8 @@ class HttpServerModule(private val reactContext: ReactApplicationContext) :
                 if (status == TextToSpeech.SUCCESS) {
                     ttsReady = true
                     Log.d(TAG, "TextToSpeech initialized (engine=$preferredEngine)")
+                    // Cache available voices so WebView polyfill can enumerate them
+                    cacheTtsVoices()
                 } else {
                     Log.e(TAG, "TextToSpeech initialization failed: $status")
                 }
@@ -143,6 +146,47 @@ class HttpServerModule(private val reactContext: ReactApplicationContext) :
             }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to initialize TTS: ${e.message}")
+        }
+    }
+
+    /**
+     * Cache available TTS voices for the WebView speechSynthesis polyfill.
+     * Exposes Google TTS voices (and any other engine voices) so web apps
+     * can enumerate and select them via speechSynthesis.getVoices().
+     */
+    private fun cacheTtsVoices() {
+        try {
+            val ttsEngine = tts ?: return
+            val voices = mutableListOf<Map<String, String>>()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                for (voice in ttsEngine.voices) {
+                    voices.add(mapOf(
+                        "name" to voice.name,
+                        "lang" to voice.locale.toLanguageTag(),
+                        "voiceUri" to voice.name,
+                        "localService" to (!voice.isNetworkConnectionRequired).toString(),
+                        "default" to (voices.isEmpty()).toString()  // first voice is default
+                    ))
+                }
+            }
+            // Fallback: if no voices via API, create voice from default engine info
+            if (voices.isEmpty()) {
+                val defaultLocale = ttsEngine.defaultVoice?.locale ?: ttsEngine.language ?: Locale.getDefault()
+                voices.add(mapOf(
+                    "name" to "Default TTS",
+                    "lang" to defaultLocale.toLanguageTag(),
+                    "voiceUri" to "default",
+                    "localService" to "true",
+                    "default" to "true"
+                ))
+            }
+            ttsVoicesCache = voices
+            Log.d(TAG, "TTS voices cached: ${voices.size} voices")
+            for (v in voices) {
+                Log.d(TAG, "  Voice: ${v["name"]} (${v["lang"]})")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to cache TTS voices: ${e.message}")
         }
     }
 
@@ -769,8 +813,9 @@ class HttpServerModule(private val reactContext: ReactApplicationContext) :
             "tts" -> {
                 val text = params?.optString("text", "") ?: ""
                 val language = params?.optString("language", "") ?: ""
+                val voice = params?.optString("voice", "") ?: ""
                 if (text.isNotEmpty()) {
-                    speakText(text, language.ifEmpty { null })
+                    speakText(text, language.ifEmpty { null }, voice.ifEmpty { null })
                     return JSONObject().apply {
                         put("executed", true)
                         put("command", command)
@@ -1059,15 +1104,45 @@ class HttpServerModule(private val reactContext: ReactApplicationContext) :
     }
 
     /**
+     * Return the list of available TTS voices as a JSON array.
+     * Called by the WebView speechSynthesis polyfill to populate getVoices().
+     */
+    @ReactMethod
+    fun getTtsVoices(promise: Promise) {
+        try {
+            if (!ttsReady || ttsVoicesCache.isEmpty()) {
+                // Try to re-cache if not ready
+                cacheTtsVoices()
+            }
+            val voices = Arguments.createArray()
+            for (voice in ttsVoicesCache) {
+                val v = Arguments.createMap()
+                v.putString("name", voice["name"] ?: "")
+                v.putString("lang", voice["lang"] ?: "")
+                v.putString("voiceUri", voice["voiceUri"] ?: "")
+                v.putBoolean("localService", voice["localService"] == "true")
+                v.putBoolean("default", voice["default"] == "true")
+                voices.pushMap(v)
+            }
+            promise.resolve(voices)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to get TTS voices: ${e.message}")
+            promise.reject("TTS_ERROR", e.message)
+        }
+    }
+
+    /**
      * Speak text using the native Android TTS engine.
      * Exposed as a @ReactMethod so the WebView speechSynthesis polyfill can call it
      * via NativeModules.HttpServerModule.speak() from React Native.
+     * @param voiceUri optional voice name to use (from getTtsVoices)
      */
     @ReactMethod
-    fun speak(text: String, language: String, promise: Promise) {
+    fun speak(text: String, language: String, voiceUri: String, promise: Promise) {
         try {
             val lang = if (language.isNotEmpty()) language else null
-            speakText(text, lang)
+            val voice = if (voiceUri.isNotEmpty() && voiceUri != "default") voiceUri else null
+            speakText(text, lang, voice)
             promise.resolve(true)
         } catch (e: Exception) {
             Log.e(TAG, "Failed to speak text", e)
@@ -1457,27 +1532,40 @@ class HttpServerModule(private val reactContext: ReactApplicationContext) :
         }
     }
 
-    private fun speakText(text: String, language: String? = null) {
+    private fun speakText(text: String, language: String? = null, voiceName: String? = null) {
         try {
             if (tts != null && ttsReady) {
-                // Determine the target locale
-                val targetLocale = if (!language.isNullOrEmpty()) {
-                    parseLocale(language)
-                } else {
-                    detectLocaleForText(text)
+                // If a specific voice name is requested, try to find and set it
+                if (!voiceName.isNullOrEmpty() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                    val matchingVoice = tts?.voices?.find { it.name == voiceName }
+                    if (matchingVoice != null) {
+                        val setResult = tts?.setVoice(matchingVoice)
+                        Log.d(TAG, "TTS set voice: $voiceName (result=$setResult)")
+                    } else {
+                        Log.w(TAG, "TTS voice not found: $voiceName, using locale-based selection")
+                        // Fall through to locale-based selection
+                    }
                 }
 
-                // Set the language on the TTS engine
-                val result = tts?.setLanguage(targetLocale)
-                if (result == TextToSpeech.LANG_MISSING_DATA || result == TextToSpeech.LANG_NOT_SUPPORTED) {
-                    Log.w(TAG, "TTS language not supported: $targetLocale, falling back to default")
-                    tts?.setLanguage(Locale.getDefault())
-                } else {
-                    Log.d(TAG, "TTS language set to: $targetLocale")
+                // If no voice was set (or pre-Lollipop), use locale-based selection
+                if (voiceName.isNullOrEmpty() || tts?.voice == null) {
+                    val targetLocale = if (!language.isNullOrEmpty()) {
+                        parseLocale(language)
+                    } else {
+                        detectLocaleForText(text)
+                    }
+
+                    val result = tts?.setLanguage(targetLocale)
+                    if (result == TextToSpeech.LANG_MISSING_DATA || result == TextToSpeech.LANG_NOT_SUPPORTED) {
+                        Log.w(TAG, "TTS language not supported: $targetLocale, falling back to default")
+                        tts?.setLanguage(Locale.getDefault())
+                    } else {
+                        Log.d(TAG, "TTS language set to: $targetLocale")
+                    }
                 }
 
                 tts?.speak(text, TextToSpeech.QUEUE_FLUSH, null, "freekiosk_tts_${System.currentTimeMillis()}")
-                Log.d(TAG, "TTS speaking: $text (locale: $targetLocale)")
+                Log.d(TAG, "TTS speaking: $text (voice=$voiceName)")
             } else {
                 // TTS not ready, try to reinitialize
                 Log.w(TAG, "TTS not ready, reinitializing...")
@@ -1485,7 +1573,7 @@ class HttpServerModule(private val reactContext: ReactApplicationContext) :
                 // Retry after a short delay
                 android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
                     if (ttsReady) {
-                        speakText(text, language)
+                        speakText(text, language, voiceName)
                     }
                 }, 1000)
             }

--- a/src/components/WebViewComponent.tsx
+++ b/src/components/WebViewComponent.tsx
@@ -328,20 +328,62 @@ const WebViewComponent = forwardRef<WebViewComponentRef, WebViewComponentProps>(
     // Android WebView does not implement the Web Speech API (speechSynthesis).
     // This polyfill bridges window.speechSynthesis.speak() to FreeKiosk's native
     // Android TextToSpeech engine via postMessage → React Native → NativeModules.
+    // It also enumerates real TTS voices (Google TTS etc.) via async query.
     // This allows web apps that use TTS to work transparently in kiosk mode.
     (function() {
       // Only polyfill if speechSynthesis is missing or non-functional
       if (window.speechSynthesis && typeof window.speechSynthesis.speak === 'function') {
-        // Test if it actually works by checking for voices
         try {
-          var voices = window.speechSynthesis.getVoices();
-          if (voices && voices.length > 0) return; // Native implementation works
+          var testVoices = window.speechSynthesis.getVoices();
+          // If native implementation returns voices, it might be real. Still polyfill
+          // because Android WebView speechSynthesis is notoriously broken (returns
+          // voices but speak() is a no-op). Only skip if there are > 2 voices.
+          if (testVoices && testVoices.length > 2) return;
         } catch(e) {}
-        // No voices = non-functional, polyfill it
       }
 
+      var _fkVoices = [];
+      var _fkVoicesLoaded = false;
+      var _fkVoicesChangedCbs = [];
       var _fkSpeaking = false;
       var _fkEndTimer = null;
+      var _fkPendingSpeak = null;  // utterance queued while voices not yet loaded
+
+      // Request real TTS voices from native Android
+      function _fkLoadVoices() {
+        window.ReactNativeWebView.postMessage(JSON.stringify({
+          type: 'SPEECH_SYNTH_GET_VOICES'
+        }));
+      }
+
+      // Called from native via injectJavaScript when voices are ready
+      window.__fkSetVoices = function(voicesJson) {
+        try {
+          var voices = JSON.parse(voicesJson);
+          _fkVoices = voices.map(function(v, i) {
+            return {
+              default: v.default || (i === 0),
+              lang: v.lang || 'en-US',
+              localService: v.localService !== false,
+              name: v.name || ('Voice ' + i),
+              voiceURI: v.voiceUri || v.name || ('voice-' + i)
+            };
+          });
+          _fkVoicesLoaded = true;
+          // Fire voiceschanged event for each registered callback
+          var evt = new Event('voiceschanged');
+          _fkVoicesChangedCbs.forEach(function(cb) { try { cb(evt); } catch(e) {} });
+          _fkVoicesChangedCbs = [];
+          // If an utterance was queued before voices loaded, speak it now
+          if (_fkPendingSpeak) {
+            var u = _fkPendingSpeak;
+            _fkPendingSpeak = null;
+            synth.speak(u);
+          }
+        } catch(e) {
+          console.error('[FreeKiosk] Failed to parse voices:', e);
+        }
+      };
 
       function FKSpeechSynthesisUtterance(text) {
         this.text = text || '';
@@ -360,27 +402,41 @@ const WebViewComponent = forwardRef<WebViewComponentRef, WebViewComponentProps>(
       }
       window.SpeechSynthesisUtterance = FKSpeechSynthesisUtterance;
 
-      var _fkVoice = {
-        default: true,
-        lang: navigator.language || 'en-US',
-        localService: true,
-        name: 'FreeKiosk Native TTS',
-        voiceURI: 'freekiosk-native'
-      };
-
-      var _fkVoicesChangedCb = null;
       var synth = {
         speaking: false,
         pending: false,
         paused: false,
         speak: function(utterance) {
           if (!utterance || !utterance.text) return;
+          // If voices not yet loaded, queue the utterance
+          if (!_fkVoicesLoaded) {
+            _fkPendingSpeak = utterance;
+            _fkLoadVoices();
+            return;
+          }
           this.speaking = true;
           _fkSpeaking = true;
+          // Pick the best voice: use utterance.voice if set, else find matching lang
+          var voiceUri = '';
+          var lang = utterance.lang || '';
+          if (utterance.voice && utterance.voice.voiceURI) {
+            voiceUri = utterance.voice.voiceURI;
+            lang = utterance.voice.lang || lang;
+          } else if (lang) {
+            // Find a voice matching the requested language
+            var exactMatch = _fkVoices.find(function(v) { return v.lang === lang; });
+            var prefixMatch = _fkVoices.find(function(v) { return v.lang.indexOf(lang.split('-')[0]) === 0; });
+            var bestVoice = exactMatch || prefixMatch || (utterance.voice || (_fkVoices[0] || null));
+            if (bestVoice && bestVoice.voiceURI) {
+              voiceUri = bestVoice.voiceURI;
+              lang = bestVoice.lang || lang;
+            }
+          }
           window.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'SPEECH_SYNTH_SPEAK',
             text: utterance.text,
-            lang: utterance.lang || '',
+            lang: lang,
+            voiceUri: voiceUri,
             rate: utterance.rate || 1,
             pitch: utterance.pitch || 1,
             volume: utterance.volume || 1
@@ -388,9 +444,9 @@ const WebViewComponent = forwardRef<WebViewComponentRef, WebViewComponentProps>(
           if (utterance.onstart) {
             try { utterance.onstart(new Event('start')); } catch(e) {}
           }
-          // Estimate duration and fire onend (rough: 80ms per character)
+          // Estimate duration and fire onend (rough: 100ms per character for normal rate)
           if (_fkEndTimer) clearTimeout(_fkEndTimer);
-          var estimatedMs = Math.max(500, utterance.text.length * 80);
+          var estimatedMs = Math.max(500, utterance.text.length * 100 / (utterance.rate || 1));
           var self = this;
           var utt = utterance;
           _fkEndTimer = setTimeout(function() {
@@ -404,33 +460,51 @@ const WebViewComponent = forwardRef<WebViewComponentRef, WebViewComponentProps>(
         cancel: function() {
           this.speaking = false;
           _fkSpeaking = false;
+          _fkPendingSpeak = null;
           if (_fkEndTimer) { clearTimeout(_fkEndTimer); _fkEndTimer = null; }
           window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'SPEECH_SYNTH_CANCEL' }));
         },
         pause: function() { this.paused = true; },
         resume: function() { this.paused = false; },
-        getVoices: function() { return [_fkVoice]; },
+        getVoices: function() {
+          // Trigger async load on first call (browsers typically call getVoices()
+          // and then listen for voiceschanged event to get the real list)
+          if (!_fkVoicesLoaded && _fkVoices.length === 0) {
+            _fkLoadVoices();
+          }
+          return _fkVoices.slice();
+        },
         addEventListener: function(type, fn) {
-          if (type === 'voiceschanged') _fkVoicesChangedCb = fn;
+          if (type === 'voiceschanged') {
+            if (_fkVoicesLoaded) {
+              // Voices already loaded, fire immediately
+              try { fn(new Event('voiceschanged')); } catch(e) {}
+            } else {
+              _fkVoicesChangedCbs.push(fn);
+            }
+          }
         },
         removeEventListener: function(type, fn) {
-          if (type === 'voiceschanged' && _fkVoicesChangedCb === fn) _fkVoicesChangedCb = null;
+          if (type === 'voiceschanged') {
+            _fkVoicesChangedCbs = _fkVoicesChangedCbs.filter(function(cb) { return cb !== fn; });
+          }
         }
       };
       Object.defineProperty(synth, 'onvoiceschanged', {
-        get: function() { return _fkVoicesChangedCb; },
-        set: function(fn) { _fkVoicesChangedCb = fn; }
+        get: function() { return _fkVoicesChangedCbs[0] || null; },
+        set: function(fn) {
+          _fkVoicesChangedCbs = fn ? [fn] : [];
+          if (fn && _fkVoicesLoaded) {
+            try { fn(new Event('voiceschanged')); } catch(e) {}
+          }
+        }
       });
       Object.defineProperty(window, 'speechSynthesis', {
         get: function() { return synth; },
         configurable: true
       });
-      // Fire voiceschanged so apps that wait for voices discover ours
-      setTimeout(function() {
-        if (_fkVoicesChangedCb) {
-          try { _fkVoicesChangedCb(new Event('voiceschanged')); } catch(e) {}
-        }
-      }, 100);
+      // Start loading voices immediately
+      _fkLoadVoices();
     })();
 
     // PDF link interception: prevent <a download href="...pdf"> from triggering
@@ -543,7 +617,7 @@ const WebViewComponent = forwardRef<WebViewComponentRef, WebViewComponentProps>(
         } else if (data.type === 'SPEECH_SYNTH_SPEAK') {
           // speechSynthesis polyfill: bridge to native Android TTS
           if (HttpServerModule?.speak) {
-            HttpServerModule.speak(data.text || '', data.lang || '')
+            HttpServerModule.speak(data.text || '', data.lang || '', data.voiceUri || '')
               .catch((err: any) => console.error('[WebView] TTS speak failed:', err));
           }
         } else if (data.type === 'SPEECH_SYNTH_CANCEL') {
@@ -551,6 +625,21 @@ const WebViewComponent = forwardRef<WebViewComponentRef, WebViewComponentProps>(
           if (HttpServerModule?.stopSpeaking) {
             HttpServerModule.stopSpeaking()
               .catch((err: any) => console.error('[WebView] TTS cancel failed:', err));
+          }
+        } else if (data.type === 'SPEECH_SYNTH_GET_VOICES') {
+          // speechSynthesis polyfill: query available TTS voices from native
+          if (HttpServerModule?.getTtsVoices) {
+            HttpServerModule.getTtsVoices()
+              .then((voices: any[]) => {
+                const voicesJson = JSON.stringify(voices || []);
+                // Use JSON.stringify on the already-stringified JSON to properly escape
+                // quotes and special chars for injection into a JS string literal
+                const safeArg = JSON.stringify(voicesJson);
+                webViewRef.current?.injectJavaScript(
+                  `window.__fkSetVoices && window.__fkSetVoices(${safeArg}); true;`
+                );
+              })
+              .catch((err: any) => console.error('[WebView] TTS getVoices failed:', err));
           }
         } else if (data.type === 'PRINT_REQUEST') {
           // Handle print request from window.print()


### PR DESCRIPTION
Expose native Android TTS voices to WebView via speechSynthesis.getVoices(). Web apps can now discover and select specific voices (Google TTS etc.) through the standard Web Speech API instead of getting a single hardcoded placeholder.

## 📝 Description

Expose native Android TTS voices to WebView via `speechSynthesis.getVoices()`. Web apps can now discover and select specific voices (Google TTS etc.) through the standard Web Speech API instead of getting a single hardcoded placeholder.

**Native side (HttpServerModule.kt):**
- Cache TTS voices on init via `cacheTtsVoices()` for fast enumeration
- New `getTtsVoices()` ReactMethod returns all available voices (name, lang, voiceUri, localService, default)
- `speak()` now accepts optional `voiceUri` parameter to select a specific voice
- REST API `/api/tts` now accepts optional `voice` param for voice selection

**WebView side (WebViewComponent.tsx):**
- Polyfill loads real voices asynchronously on first `getVoices()` call
- Supports `voiceschanged` event with multiple listeners
- Auto-selects best voice by matching `utterance.lang` to available voices
- Queues utterances spoken before voices finish loading
- Properly passes voice URI through to native TTS engine

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement

## ✅ Testing

Please describe the tests you ran to verify your changes:

- [x] Tested on real Android device
- [x] Tested in Device Owner mode
- [ ] Tested on multiple Android versions: ___
- [x] No regressions found

**Device(s) tested:**
- Device: Huawei NDL-W19EEA (MediaPad)
- Android version: Android 14 (API 36)

## 📸 Screenshots/Videos

N/A — TTS is audio-only. Verified via console logs that `speechSynthesis.getVoices()` returns multiple Google TTS voices and `speechSynthesis.speak()` uses the selected voice.

## 📋 Checklist

- [x] My code follows the project's code style
- [x] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have tested on a real device (not just emulator)
- [x] All existing tests still pass

## 🔗 Related Issues/PRs

N/A

## 📝 Additional Notes

The polyfill now gracefully handles the case where `getVoices()` is called before voices are loaded (common in web apps) — it queues the first `speak()` call and fires it once voices arrive. Duration estimation for `onend` event was also adjusted to account for speech rate.
