### PR TITLE
Add WebView restart button (long-press to reload)

### DIFF
--- a/src/components/RestartButton.tsx
+++ b/src/components/RestartButton.tsx
@@ -1,0 +1,158 @@
+/**
+ * FreeKiosk - RestartButton
+ *
+ * Top-right overlay button that reloads the WebView on a long-press. While held, the
+ * circle fills with grey clockwise (pie/progress style) over `longPressSeconds`; releasing
+ * before completion cancels and empties the ring. Completion triggers onTrigger().
+ *
+ * The circular fill is built without any SVG dependency: two clipped half-discs are
+ * rotated around the circle center (transformOrigin), phase 1 sweeps the right half
+ * (0→50%), phase 2 the left half (50→100%), producing a clean clockwise fill from 12 o'clock.
+ */
+import React, { useRef } from 'react';
+import { Animated, Easing, Pressable, StyleSheet, View } from 'react-native';
+import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
+
+interface RestartButtonProps {
+  /** How long (seconds) the button must be held before it triggers. */
+  longPressSeconds: number;
+  /** Called when the hold completes. */
+  onTrigger: () => void;
+}
+
+const SIZE = 50;
+const HALF = SIZE / 2;
+const FILL = '#616161'; // solid grey (filled)
+const TRACK = 'rgba(97, 97, 97, 0.28)'; // faint grey (empty)
+
+const RestartButton: React.FC<RestartButtonProps> = ({ longPressSeconds, onTrigger }) => {
+  const progress = useRef(new Animated.Value(0)).current;
+  const completedRef = useRef(false);
+  const durationMs = Math.max(1, longPressSeconds) * 1000;
+
+  const start = () => {
+    completedRef.current = false;
+    progress.setValue(0);
+    Animated.timing(progress, {
+      toValue: 1,
+      duration: durationMs,
+      easing: Easing.linear,
+      useNativeDriver: true,
+    }).start(({ finished }) => {
+      if (finished) {
+        completedRef.current = true;
+        onTrigger();
+        progress.setValue(0); // reset the fill after firing
+      }
+    });
+  };
+
+  const cancel = () => {
+    if (completedRef.current) return; // hold already completed and fired
+    progress.stopAnimation();
+    Animated.timing(progress, {
+      toValue: 0,
+      duration: 200,
+      easing: Easing.out(Easing.quad),
+      useNativeDriver: true,
+    }).start();
+  };
+
+  // Right half fills over the first 50%, left half over the second 50%.
+  const rightRotate = progress.interpolate({
+    inputRange: [0, 0.5, 1],
+    outputRange: ['0deg', '180deg', '180deg'],
+    extrapolate: 'clamp',
+  });
+  const leftRotate = progress.interpolate({
+    inputRange: [0, 0.5, 1],
+    outputRange: ['0deg', '0deg', '180deg'],
+    extrapolate: 'clamp',
+  });
+
+  return (
+    <Pressable onPressIn={start} onPressOut={cancel} style={styles.wrap}>
+      <View style={styles.track}>
+        {/* Right half of the circle (fills during the first half of the hold) */}
+        <View style={styles.rightClip}>
+          <Animated.View style={[styles.rightFill, { transform: [{ rotate: rightRotate }] }]} />
+        </View>
+        {/* Left half of the circle (fills during the second half of the hold) */}
+        <View style={styles.leftClip}>
+          <Animated.View style={[styles.leftFill, { transform: [{ rotate: leftRotate }] }]} />
+        </View>
+      </View>
+      <MaterialCommunityIcons name="refresh" size={28} color="#ffffff" style={styles.icon} />
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  wrap: {
+    position: 'absolute',
+    top: 20,
+    right: 20,
+    width: SIZE,
+    height: SIZE,
+    borderRadius: HALF,
+    alignItems: 'center',
+    justifyContent: 'center',
+    elevation: 8,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    zIndex: 1000,
+  },
+  track: {
+    position: 'absolute',
+    width: SIZE,
+    height: SIZE,
+    borderRadius: HALF,
+    backgroundColor: TRACK,
+    overflow: 'hidden',
+  },
+  rightClip: {
+    position: 'absolute',
+    left: HALF,
+    top: 0,
+    width: HALF,
+    height: SIZE,
+    overflow: 'hidden',
+  },
+  rightFill: {
+    position: 'absolute',
+    left: -HALF,
+    top: 0,
+    width: HALF,
+    height: SIZE,
+    backgroundColor: FILL,
+    borderTopLeftRadius: HALF,
+    borderBottomLeftRadius: HALF,
+    transformOrigin: 'right center',
+  },
+  leftClip: {
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    width: HALF,
+    height: SIZE,
+    overflow: 'hidden',
+  },
+  leftFill: {
+    position: 'absolute',
+    left: HALF,
+    top: 0,
+    width: HALF,
+    height: SIZE,
+    backgroundColor: FILL,
+    borderTopRightRadius: HALF,
+    borderBottomRightRadius: HALF,
+    transformOrigin: 'left center',
+  },
+  icon: {
+    zIndex: 1,
+  },
+});
+
+export default RestartButton;

--- a/src/screens/KioskScreen.tsx
+++ b/src/screens/KioskScreen.tsx
@@ -27,6 +27,7 @@ import { ScreenScheduleRule, getNextWakeTime, getActiveSleepRule, getNextSleepTi
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '../navigation/AppNavigator';
 import Icon from '../components/Icon';
+import RestartButton from '../components/RestartButton';
 import { revokeSettingsAccess } from '../utils/authState';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 
@@ -182,6 +183,10 @@ const KioskScreen: React.FC<KioskScreenProps> = ({ navigation }) => {
   const [webViewBackButtonXPercent, setWebViewBackButtonXPercent] = useState<number>(2);
   const [webViewBackButtonYPercent, setWebViewBackButtonYPercent] = useState<number>(10);
   const [canGoBack, setCanGoBack] = useState<boolean>(false);
+
+  // Restart Button (top-right overlay, long-press reloads the WebView)
+  const [restartButtonEnabled, setRestartButtonEnabled] = useState<boolean>(true);
+  const [restartButtonLongPressSeconds, setRestartButtonLongPressSeconds] = useState<number>(5);
 
   // URL Filtering states
   const [urlFilterEnabled, setUrlFilterEnabled] = useState<boolean>(false);
@@ -1611,6 +1616,11 @@ const KioskScreen: React.FC<KioskScreenProps> = ({ navigation }) => {
       setWebViewBackButtonEnabled(savedWebViewBackButtonEnabled);
       setWebViewBackButtonXPercent(savedWebViewBackButtonXPercent);
       setWebViewBackButtonYPercent(savedWebViewBackButtonYPercent);
+
+      const savedRestartButtonEnabled = bool(K.RESTART_BUTTON_ENABLED, true);
+      const savedRestartButtonLongPressSeconds = num(K.RESTART_BUTTON_LONG_PRESS_SECONDS, 5);
+      setRestartButtonEnabled(savedRestartButtonEnabled);
+      setRestartButtonLongPressSeconds(savedRestartButtonLongPressSeconds);
       
       // Load Auto-Brightness settings
       const savedAutoBrightnessEnabled = bool(K.AUTO_BRIGHTNESS_ENABLED, false);
@@ -2706,6 +2716,17 @@ const KioskScreen: React.FC<KioskScreenProps> = ({ navigation }) => {
             </View>
           </TouchableWithoutFeedback>
         </View>
+      )}
+
+      {/* Restart button - always present over WebView content. Long-press reloads the
+          WebView (remount via webViewKey). Top-right, red, circular reload arrow. A short
+          tap does nothing (no onPress) so it can't be triggered accidentally. Hidden on the
+          dashboard grid, where no WebView is mounted to reload. */}
+      {restartButtonEnabled && displayMode === 'webview' && !(dashboardModeEnabled && dashboardShowGrid) && (
+        <RestartButton
+          longPressSeconds={restartButtonLongPressSeconds}
+          onTrigger={() => setWebViewKey(prev => prev + 1)}
+        />
       )}
 
       {/* Screensaver overlay - dim mode uses black/transparent based on brightness; URL/video modes render content */}

--- a/src/screens/settings/SettingsScreenNew.tsx
+++ b/src/screens/settings/SettingsScreenNew.tsx
@@ -156,7 +156,9 @@ const SettingsScreenNew: React.FC<SettingsScreenProps> = ({ navigation }) => {
   const [webViewBackButtonEnabled, setWebViewBackButtonEnabled] = useState<boolean>(false);
   const [webViewBackButtonXPercent, setWebViewBackButtonXPercent] = useState<string>('2');
   const [webViewBackButtonYPercent, setWebViewBackButtonYPercent] = useState<string>('10');
-  
+  const [restartButtonEnabled, setRestartButtonEnabled] = useState<boolean>(true);
+  const [restartButtonLongPressSeconds, setRestartButtonLongPressSeconds] = useState<number>(5);
+
   // Auto-Brightness states
   const [autoBrightnessEnabled, setAutoBrightnessEnabled] = useState<boolean>(false);
   const [autoBrightnessMin, setAutoBrightnessMin] = useState<number>(0.1);
@@ -526,7 +528,11 @@ const SettingsScreenNew: React.FC<SettingsScreenProps> = ({ navigation }) => {
     const savedWebViewBackButtonEnabled = await StorageService.getWebViewBackButtonEnabled();
     const savedWebViewBackButtonXPercent = await StorageService.getWebViewBackButtonXPercent();
     const savedWebViewBackButtonYPercent = await StorageService.getWebViewBackButtonYPercent();
-    
+
+    // Restart Button settings
+    const savedRestartButtonEnabled = await StorageService.getRestartButtonEnabled();
+    const savedRestartButtonLongPressSeconds = await StorageService.getRestartButtonLongPressSeconds();
+
     // Auto-Brightness settings
     const savedAutoBrightnessEnabled = await StorageService.getAutoBrightnessEnabled();
     const savedAutoBrightnessMin = await StorageService.getAutoBrightnessMin();
@@ -590,6 +596,8 @@ const SettingsScreenNew: React.FC<SettingsScreenProps> = ({ navigation }) => {
     setWebViewBackButtonEnabled(savedWebViewBackButtonEnabled);
     setWebViewBackButtonXPercent(String(savedWebViewBackButtonXPercent));
     setWebViewBackButtonYPercent(String(savedWebViewBackButtonYPercent));
+    setRestartButtonEnabled(savedRestartButtonEnabled);
+    setRestartButtonLongPressSeconds(savedRestartButtonLongPressSeconds);
     setAutoBrightnessEnabled(savedAutoBrightnessEnabled);
     setAutoBrightnessMin(savedAutoBrightnessMin);
     setAutoBrightnessMax(savedAutoBrightnessMax);
@@ -1473,6 +1481,10 @@ const SettingsScreenNew: React.FC<SettingsScreenProps> = ({ navigation }) => {
       const yPercent = parseFloat(webViewBackButtonYPercent);
       await StorageService.saveWebViewBackButtonXPercent(isNaN(xPercent) ? 2 : Math.max(0, Math.min(100, xPercent)));
       await StorageService.saveWebViewBackButtonYPercent(isNaN(yPercent) ? 10 : Math.max(0, Math.min(100, yPercent)));
+
+      // Save Restart Button settings
+      await StorageService.saveRestartButtonEnabled(restartButtonEnabled);
+      await StorageService.saveRestartButtonLongPressSeconds(Math.max(1, Math.min(10, restartButtonLongPressSeconds)));
     } else {
       await StorageService.saveUrlRotationEnabled(false);
       await StorageService.saveUrlPlannerEnabled(false);
@@ -1886,6 +1898,10 @@ const SettingsScreenNew: React.FC<SettingsScreenProps> = ({ navigation }) => {
               setWebViewBackButtonXPercent('2');
               setWebViewBackButtonYPercent('10');
             }}
+            restartButtonEnabled={restartButtonEnabled}
+            onRestartButtonEnabledChange={setRestartButtonEnabled}
+            restartButtonLongPressSeconds={restartButtonLongPressSeconds}
+            onRestartButtonLongPressSecondsChange={setRestartButtonLongPressSeconds}
             inactivityReturnEnabled={inactivityReturnEnabled}
             onInactivityReturnEnabledChange={setInactivityReturnEnabled}
             inactivityReturnDelay={inactivityReturnDelay}

--- a/src/screens/settings/tabs/GeneralTab.tsx
+++ b/src/screens/settings/tabs/GeneralTab.tsx
@@ -9,6 +9,7 @@ import {
   SettingsSection,
   SettingsInput,
   SettingsSwitch,
+  SettingsSlider,
   SettingsModeSelector,
   SettingsInfoBox,
   SettingsButton,
@@ -110,7 +111,13 @@ interface GeneralTabProps {
   webViewBackButtonYPercent: string;
   onWebViewBackButtonYPercentChange: (value: string) => void;
   onResetWebViewBackButtonPosition: () => void;
-  
+
+  // Restart Button (webview only): long-press reloads the WebView
+  restartButtonEnabled: boolean;
+  onRestartButtonEnabledChange: (value: boolean) => void;
+  restartButtonLongPressSeconds: number;
+  onRestartButtonLongPressSecondsChange: (value: number) => void;
+
   // Inactivity Return to Home (webview only)
   inactivityReturnEnabled: boolean;
   onInactivityReturnEnabledChange: (value: boolean) => void;
@@ -216,6 +223,10 @@ const GeneralTab: React.FC<GeneralTabProps> = ({
   webViewBackButtonYPercent,
   onWebViewBackButtonYPercentChange,
   onResetWebViewBackButtonPosition,
+  restartButtonEnabled,
+  onRestartButtonEnabledChange,
+  restartButtonLongPressSeconds,
+  onRestartButtonLongPressSecondsChange,
   inactivityReturnEnabled,
   onInactivityReturnEnabledChange,
   inactivityReturnDelay,
@@ -1035,7 +1046,36 @@ const GeneralTab: React.FC<GeneralTabProps> = ({
           )}
         </SettingsSection>
       )}
-      
+
+      {/* Restart Button - WebView only. Top-right red button, long-press reloads the page. */}
+      {displayMode === 'webview' && (
+        <SettingsSection title="Restart Button" icon="refresh">
+          <SettingsSwitch
+            label="Enable Restart Button"
+            hint="Show a red button in the top-right corner. Long-press it to reload the current web page."
+            value={restartButtonEnabled}
+            onValueChange={onRestartButtonEnabledChange}
+          />
+
+          {restartButtonEnabled && (
+            <>
+              <View style={styles.rotationSpacer} />
+              <SettingsSlider
+                label="Long-press Duration"
+                hint="How long the button must be held before the page reloads."
+                icon="refresh"
+                value={restartButtonLongPressSeconds}
+                onValueChange={onRestartButtonLongPressSecondsChange}
+                minimumValue={1}
+                maximumValue={10}
+                step={1}
+                unit="s"
+              />
+            </>
+          )}
+        </SettingsSection>
+      )}
+
       {/* Background Apps - WebView mode only */}
       {displayMode === 'webview' && (
         <SettingsSection title="Background Apps" icon="apps">

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -84,6 +84,9 @@ const KEYS = {
   WEBVIEW_BACK_BUTTON_ENABLED: '@kiosk_webview_back_button_enabled',
   WEBVIEW_BACK_BUTTON_X_PERCENT: '@kiosk_webview_back_button_x_percent',
   WEBVIEW_BACK_BUTTON_Y_PERCENT: '@kiosk_webview_back_button_y_percent',
+  // Restart Button (WebView reload via long-press, top-right)
+  RESTART_BUTTON_ENABLED: '@kiosk_restart_button_enabled',
+  RESTART_BUTTON_LONG_PRESS_SECONDS: '@kiosk_restart_button_long_press_seconds',
   // Auto-Brightness
   AUTO_BRIGHTNESS_ENABLED: '@kiosk_auto_brightness_enabled',
   AUTO_BRIGHTNESS_MIN: '@kiosk_auto_brightness_min',
@@ -406,6 +409,9 @@ export const StorageService = {
         KEYS.WEBVIEW_BACK_BUTTON_ENABLED,
         KEYS.WEBVIEW_BACK_BUTTON_X_PERCENT,
         KEYS.WEBVIEW_BACK_BUTTON_Y_PERCENT,
+        // Restart Button
+        KEYS.RESTART_BUTTON_ENABLED,
+        KEYS.RESTART_BUTTON_LONG_PRESS_SECONDS,
         // Auto-Brightness
         KEYS.AUTO_BRIGHTNESS_ENABLED,
         KEYS.AUTO_BRIGHTNESS_MIN,
@@ -1696,6 +1702,43 @@ export const StorageService = {
     } catch (error) {
       console.error('Error getting webview back button Y percent:', error);
       return 10;
+    }
+  },
+
+  // Restart Button (top-right, long-press to reload the WebView)
+  saveRestartButtonEnabled: async (value: boolean): Promise<void> => {
+    try {
+      await AsyncStorage.setItem(KEYS.RESTART_BUTTON_ENABLED, JSON.stringify(value));
+    } catch (error) {
+      console.error('Error saving restart button enabled:', error);
+    }
+  },
+
+  getRestartButtonEnabled: async (): Promise<boolean> => {
+    try {
+      const value = await AsyncStorage.getItem(KEYS.RESTART_BUTTON_ENABLED);
+      return value ? JSON.parse(value) : true; // Enabled by default (always-present button)
+    } catch (error) {
+      console.error('Error getting restart button enabled:', error);
+      return true;
+    }
+  },
+
+  saveRestartButtonLongPressSeconds: async (value: number): Promise<void> => {
+    try {
+      await AsyncStorage.setItem(KEYS.RESTART_BUTTON_LONG_PRESS_SECONDS, JSON.stringify(value));
+    } catch (error) {
+      console.error('Error saving restart button long-press seconds:', error);
+    }
+  },
+
+  getRestartButtonLongPressSeconds: async (): Promise<number> => {
+    try {
+      const value = await AsyncStorage.getItem(KEYS.RESTART_BUTTON_LONG_PRESS_SECONDS);
+      return value ? JSON.parse(value) : 5; // 5s long-press by default
+    } catch (error) {
+      console.error('Error getting restart button long-press seconds:', error);
+      return 5;
     }
   },
 


### PR DESCRIPTION
# ─────────── PULL REQUEST BODY ───────────

## 📝 Description

Adds an always-present overlay button in the top-right corner of WebView mode. Holding it fills a circular progress ring; when the hold completes, the WebView is remounted, reloading the current page. A short tap does nothing, so it cannot be triggered accidentally.

Configurable from Settings → General (WebView mode only): a switch to enable or disable the button, and a slider for the hold duration (1–10s, default 5s). Both are persisted through `StorageService`. The button is hidden when the dashboard grid is showing, since no WebView is mounted there.

The circular fill is implemented with two clipped, rotated half-discs, so it needs no new SVG dependency.

Fixes # (issue number, if applicable)

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement

## ✅ Testing

Please describe the tests you ran to verify your changes:

- [X] Tested on real Android device
- [ ] Tested in Device Owner mode
- [ ] Tested on multiple Android versions: ___
- [ ] No regressions found

`npx tsc --noEmit` is clean, and ESLint on the touched files reports the same pre-existing findings as `main` (no new ones; the new component is clean).

**Device(s) tested:**
- Device: [Samsung Galaxy Active 5]
- Android version: [Android 16]

## 📸 Screenshots/Videos

_Short screen recording of the hold-to-reload interaction, plus the new Settings section._

## 📋 Checklist

- [X] My code follows the project's code style
- [X] I have commented my code where necessary
- [X] My changes generate no new warnings
- [ ] I have updated the documentation accordingly (no docs page covers WebView overlay controls)
- [X] I have tested on a real device (not just emulator)
- [ ] All existing tests still pass

## 🔗 Related Issues/PRs

List any related issues or pull requests:
- Related to https://github.com/RushB-fr/freekiosk/issues/223

## 📝 Additional Notes

Only these five files change: `src/components/RestartButton.tsx` (new), `KioskScreen.tsx`, `SettingsScreenNew.tsx`, `tabs/GeneralTab.tsx`, `utils/storage.ts`. No native module, dependency, or build-artifact changes.
