### PR TITLE
Feature/MJPEG live camera stream with motion detection from the stream frames

### DIFF
--- a/android/app/src/main/java/com/freekiosk/api/HttpServerModule.kt
+++ b/android/app/src/main/java/com/freekiosk/api/HttpServerModule.kt
@@ -83,6 +83,7 @@ class HttpServerModule(private val reactContext: ReactApplicationContext) :
     private var jsBrightness: Int = 50
     private var jsScreensaverActive: Boolean = false
     private var jsMotionAlwaysOn: Boolean = false
+    private var jsMotionSensitivity: String = "medium"
     private var jsKioskMode: Boolean = false
     private var jsRotationEnabled: Boolean = false
     private var jsRotationUrls: List<String> = emptyList()
@@ -262,6 +263,15 @@ class HttpServerModule(private val reactContext: ReactApplicationContext) :
                 if (jsMotionActive()) MOTION_RELEASE_WAIT_MS else 0L
             }
             streamManager.releaseCamera = { emitCameraStreamState(false) }
+            // While a stream holds the camera, motion is derived from its own frames: the
+            // regular detector cannot open the sensor at the same time.
+            streamManager.motionThreshold = motionThresholdForSensitivity()
+            // Reported unconditionally: whether movement should wake the screen depends on
+            // settings and screensaver state that JS already arbitrates for the regular
+            // detector. Duplicating that decision here would drift out of sync.
+            streamManager.onMotionDetected = {
+                sendEvent("onCameraStreamMotion", Arguments.createMap())
+            }
 
             server = KioskHttpServer(
                 port = port,
@@ -1055,6 +1065,16 @@ class HttpServerModule(private val reactContext: ReactApplicationContext) :
     private fun jsMotionActive(): Boolean = jsMotionAlwaysOn || jsScreensaverActive
 
     /**
+     * Same thresholds as MotionDetector on the JS side, so switching between the two detection
+     * paths does not change how sensitive the kiosk feels.
+     */
+    private fun motionThresholdForSensitivity(): Double = when (jsMotionSensitivity) {
+        "low" -> 0.15
+        "high" -> 0.04
+        else -> 0.08
+    }
+
+    /**
      * Tell JS that a camera stream started or stopped, so MotionDetector can release the
      * camera and pick it up again afterwards.
      */
@@ -1099,8 +1119,13 @@ class HttpServerModule(private val reactContext: ReactApplicationContext) :
             if (status.has("autoBrightnessEnabled")) jsAutoBrightnessEnabled = status.getBoolean("autoBrightnessEnabled")
             if (status.has("autoBrightnessMin")) jsAutoBrightnessMin = status.getInt("autoBrightnessMin")
             if (status.has("autoBrightnessMax")) jsAutoBrightnessMax = status.getInt("autoBrightnessMax")
-            // Tells the stream manager whether motion detection may be holding the camera
+            // Tells the stream manager whether motion detection may be holding the camera,
+            // and how sensitive the stream-based detection should be
             if (status.has("motionAlwaysOn")) jsMotionAlwaysOn = status.getBoolean("motionAlwaysOn")
+            if (status.has("motionSensitivity")) {
+                jsMotionSensitivity = status.getString("motionSensitivity")
+                cameraStreamManager?.motionThreshold = motionThresholdForSensitivity()
+            }
             Log.d(TAG, "Status updated: url=$jsCurrentUrl, screensaver=$jsScreensaverActive, rotation=$jsRotationEnabled, autoBrightness=$jsAutoBrightnessEnabled")
         } catch (e: Exception) {
             Log.e(TAG, "Failed to parse status update from JS", e)

--- a/android/app/src/main/java/com/freekiosk/api/HttpServerModule.kt
+++ b/android/app/src/main/java/com/freekiosk/api/HttpServerModule.kt
@@ -281,7 +281,16 @@ class HttpServerModule(private val reactContext: ReactApplicationContext) :
                 commandHandler = { command, params -> handleCommand(command, params) },
                 screenshotProvider = { captureScreenshot() },
                 cameraPhotoProvider = { camera, quality -> cameraPhotoModule?.capturePhoto(camera, quality) },
-                cameraStreamProvider = { params -> streamManager.openClient(params) }
+                cameraStreamProvider = { params -> streamManager.openClient(params) },
+                cameraStreamDefaults = {
+                    CameraStreamManager.StreamParams(
+                        facing = streamManager.defaultFacing,
+                        fps = streamManager.defaultFps,
+                        quality = streamManager.defaultQuality,
+                        maxWidth = streamManager.defaultWidth,
+                        rotate = streamManager.defaultRotate
+                    )
+                }
             )
 
             server?.start()
@@ -1092,6 +1101,52 @@ class HttpServerModule(private val reactContext: ReactApplicationContext) :
      * remounts, so it must be able to ask the native side for the truth — otherwise motion
      * detection restarts and steals the camera from a live stream.
      */
+    /**
+     * Apply the live stream settings. Streaming stays refused until this is called with
+     * `enabled: true`, so the endpoint is opt-in like the rest of the camera features.
+     * Disabling it also drops any viewer currently connected.
+     */
+    @ReactMethod
+    fun updateCameraStreamSettings(configMap: ReadableMap, promise: Promise) {
+        try {
+            val manager = cameraStreamManager
+            if (manager == null) {
+                promise.resolve(false)
+                return
+            }
+
+            val enabled = if (configMap.hasKey("enabled")) configMap.getBoolean("enabled") else false
+            val wasEnabled = manager.enabled
+            manager.enabled = enabled
+            if (configMap.hasKey("camera")) {
+                manager.defaultFacing = configMap.getString("camera") ?: "front"
+            }
+            if (configMap.hasKey("fps")) manager.defaultFps = configMap.getInt("fps")
+            if (configMap.hasKey("quality")) manager.defaultQuality = configMap.getInt("quality")
+            if (configMap.hasKey("width")) manager.defaultWidth = configMap.getInt("width")
+            if (configMap.hasKey("rotate")) {
+                val rotate = configMap.getInt("rotate")
+                manager.defaultRotate = if (rotate < 0) null else rotate
+            }
+
+            if (wasEnabled && !enabled) {
+                Log.i(TAG, "Camera streaming disabled, dropping viewers")
+                manager.stopAll()
+            }
+
+            Log.i(
+                TAG,
+                "Camera stream settings: enabled=$enabled, camera=${manager.defaultFacing}, " +
+                    "fps=${manager.defaultFps}, quality=${manager.defaultQuality}, " +
+                    "width=${manager.defaultWidth}, rotate=${manager.defaultRotate ?: "auto"}"
+            )
+            promise.resolve(true)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to update camera stream settings", e)
+            promise.reject("UPDATE_ERROR", e.message)
+        }
+    }
+
     @ReactMethod
     fun isCameraStreaming(promise: Promise) {
         promise.resolve(cameraStreamManager?.isStreaming == true)

--- a/android/app/src/main/java/com/freekiosk/api/HttpServerModule.kt
+++ b/android/app/src/main/java/com/freekiosk/api/HttpServerModule.kt
@@ -1067,6 +1067,16 @@ class HttpServerModule(private val reactContext: ReactApplicationContext) :
 
     // ==================== JS Interface for Status Updates ====================
 
+    /**
+     * Whether a camera stream is currently running. JS state is lost whenever the kiosk screen
+     * remounts, so it must be able to ask the native side for the truth — otherwise motion
+     * detection restarts and steals the camera from a live stream.
+     */
+    @ReactMethod
+    fun isCameraStreaming(promise: Promise) {
+        promise.resolve(cameraStreamManager?.isStreaming == true)
+    }
+
     @ReactMethod
     fun updateStatus(statusJson: String) {
         // Parse status from JS and update local variables

--- a/android/app/src/main/java/com/freekiosk/api/HttpServerModule.kt
+++ b/android/app/src/main/java/com/freekiosk/api/HttpServerModule.kt
@@ -42,6 +42,7 @@ import android.accessibilityservice.AccessibilityService
 import android.os.Build
 import com.freekiosk.DeviceAdminReceiver
 import com.freekiosk.CameraPhotoModule
+import com.freekiosk.camera.CameraStreamManager
 import com.freekiosk.FreeKioskAccessibilityService
 import com.freekiosk.ScreenController
 import org.json.JSONObject
@@ -60,6 +61,12 @@ class HttpServerModule(private val reactContext: ReactApplicationContext) :
     companion object {
         private const val TAG = "HttpServerModule"
         private const val NAME = "HttpServerModule"
+
+        /**
+         * Time given to MotionDetector to release the camera before a stream opens it.
+         * Measured on a Xiaomi tablet: unmounting the CameraView takes a few hundred ms.
+         */
+        private const val MOTION_RELEASE_WAIT_MS = 1200L
     }
 
     private var server: KioskHttpServer? = null
@@ -75,6 +82,7 @@ class HttpServerModule(private val reactContext: ReactApplicationContext) :
     private var jsLoading: Boolean = false
     private var jsBrightness: Int = 50
     private var jsScreensaverActive: Boolean = false
+    private var jsMotionAlwaysOn: Boolean = false
     private var jsKioskMode: Boolean = false
     private var jsRotationEnabled: Boolean = false
     private var jsRotationUrls: List<String> = emptyList()
@@ -108,6 +116,7 @@ class HttpServerModule(private val reactContext: ReactApplicationContext) :
     
     // Camera
     private var cameraPhotoModule: CameraPhotoModule? = null
+    private var cameraStreamManager: CameraStreamManager? = null
     
     // Text-to-Speech
     private var tts: TextToSpeech? = null
@@ -240,6 +249,20 @@ class HttpServerModule(private val reactContext: ReactApplicationContext) :
                 cameraPhotoModule = CameraPhotoModule(reactContext.applicationContext)
             }
 
+            // Initialize the MJPEG stream manager and wire the camera arbitration:
+            // motion detection holds the camera through vision-camera, so it must release it
+            // before we can open a streaming session (and resume once the last viewer left).
+            val streamManager = cameraStreamManager ?: CameraStreamManager(reactContext.applicationContext).also {
+                cameraStreamManager = it
+            }
+            streamManager.prepareCamera = {
+                emitCameraStreamState(true)
+                // Give MotionDetector time to unmount its CameraView. Only worth waiting when
+                // motion detection can actually be running.
+                if (jsMotionActive()) MOTION_RELEASE_WAIT_MS else 0L
+            }
+            streamManager.releaseCamera = { emitCameraStreamState(false) }
+
             server = KioskHttpServer(
                 port = port,
                 apiKey = if (apiKey.isNullOrEmpty()) null else apiKey,
@@ -247,7 +270,8 @@ class HttpServerModule(private val reactContext: ReactApplicationContext) :
                 statusProvider = { getDeviceStatus() },
                 commandHandler = { command, params -> handleCommand(command, params) },
                 screenshotProvider = { captureScreenshot() },
-                cameraPhotoProvider = { camera, quality -> cameraPhotoModule?.capturePhoto(camera, quality) }
+                cameraPhotoProvider = { camera, quality -> cameraPhotoModule?.capturePhoto(camera, quality) },
+                cameraStreamProvider = { params -> streamManager.openClient(params) }
             )
 
             server?.start()
@@ -270,6 +294,8 @@ class HttpServerModule(private val reactContext: ReactApplicationContext) :
     @ReactMethod
     fun stopServer(promise: Promise) {
         try {
+            // Drop viewers first so the camera is released before the server goes away
+            cameraStreamManager?.stopAll()
             server?.stop()
             server = null
             releaseServerLocks()
@@ -1020,6 +1046,25 @@ class HttpServerModule(private val reactContext: ReactApplicationContext) :
             .emit(eventName, params)
     }
 
+    // ==================== Camera stream arbitration ====================
+
+    /**
+     * Whether motion detection may currently be holding the camera: it runs continuously in
+     * always-on mode, and during the screensaver otherwise.
+     */
+    private fun jsMotionActive(): Boolean = jsMotionAlwaysOn || jsScreensaverActive
+
+    /**
+     * Tell JS that a camera stream started or stopped, so MotionDetector can release the
+     * camera and pick it up again afterwards.
+     */
+    private fun emitCameraStreamState(streaming: Boolean) {
+        Log.i(TAG, "Camera stream state: streaming=$streaming")
+        sendEvent("onCameraStreamState", Arguments.createMap().apply {
+            putBoolean("streaming", streaming)
+        })
+    }
+
     // ==================== JS Interface for Status Updates ====================
 
     @ReactMethod
@@ -1044,6 +1089,8 @@ class HttpServerModule(private val reactContext: ReactApplicationContext) :
             if (status.has("autoBrightnessEnabled")) jsAutoBrightnessEnabled = status.getBoolean("autoBrightnessEnabled")
             if (status.has("autoBrightnessMin")) jsAutoBrightnessMin = status.getInt("autoBrightnessMin")
             if (status.has("autoBrightnessMax")) jsAutoBrightnessMax = status.getInt("autoBrightnessMax")
+            // Tells the stream manager whether motion detection may be holding the camera
+            if (status.has("motionAlwaysOn")) jsMotionAlwaysOn = status.getBoolean("motionAlwaysOn")
             Log.d(TAG, "Status updated: url=$jsCurrentUrl, screensaver=$jsScreensaverActive, rotation=$jsRotationEnabled, autoBrightness=$jsAutoBrightnessEnabled")
         } catch (e: Exception) {
             Log.e(TAG, "Failed to parse status update from JS", e)
@@ -1903,6 +1950,8 @@ class HttpServerModule(private val reactContext: ReactApplicationContext) :
             tts = null
             ttsReady = false
             sensorManager?.unregisterListener(this)
+            cameraStreamManager?.stopAll()
+            cameraStreamManager = null
             cameraPhotoModule = null
             Log.d(TAG, "HttpServerModule cleaned up")
         } catch (e: Exception) {

--- a/android/app/src/main/java/com/freekiosk/api/KioskHttpServer.kt
+++ b/android/app/src/main/java/com/freekiosk/api/KioskHttpServer.kt
@@ -19,7 +19,8 @@ class KioskHttpServer(
     private val commandHandler: (String, JSONObject?) -> JSONObject,
     private val screenshotProvider: (() -> java.io.InputStream?)? = null,
     private val cameraPhotoProvider: ((camera: String, quality: Int) -> java.io.InputStream?)? = null,
-    private val cameraStreamProvider: ((params: CameraStreamManager.StreamParams) -> CameraStreamManager.StreamResult)? = null
+    private val cameraStreamProvider: ((params: CameraStreamManager.StreamParams) -> CameraStreamManager.StreamResult)? = null,
+    private val cameraStreamDefaults: (() -> CameraStreamManager.StreamParams)? = null
 ) : NanoHTTPD(port) {
 
     companion object {
@@ -659,13 +660,15 @@ class KioskHttpServer(
         val provider = cameraStreamProvider
             ?: return jsonError(Response.Status.SERVICE_UNAVAILABLE, "Camera streaming not available")
 
+        // Query parameters override the configured defaults, one request at a time
         val params = session.parms ?: emptyMap()
+        val defaults = cameraStreamDefaults?.invoke()
         val streamParams = CameraStreamManager.StreamParams(
-            facing = params["camera"] ?: "back",
-            fps = (params["fps"]?.toIntOrNull() ?: 10).coerceIn(1, 30),
-            quality = (params["quality"]?.toIntOrNull() ?: 60).coerceIn(1, 100),
-            maxWidth = (params["width"]?.toIntOrNull() ?: 1280).coerceIn(160, 3840),
-            rotate = params["rotate"]?.toIntOrNull()?.let { ((it % 360) + 360) % 360 }
+            facing = params["camera"] ?: defaults?.facing ?: "front",
+            fps = (params["fps"]?.toIntOrNull() ?: defaults?.fps ?: 10).coerceIn(1, 30),
+            quality = (params["quality"]?.toIntOrNull() ?: defaults?.quality ?: 60).coerceIn(1, 100),
+            maxWidth = (params["width"]?.toIntOrNull() ?: defaults?.maxWidth ?: 1280).coerceIn(160, 3840),
+            rotate = (params["rotate"]?.toIntOrNull() ?: defaults?.rotate)?.let { ((it % 360) + 360) % 360 }
         )
 
         Log.i(TAG, "Camera stream request: $streamParams")

--- a/android/app/src/main/java/com/freekiosk/api/KioskHttpServer.kt
+++ b/android/app/src/main/java/com/freekiosk/api/KioskHttpServer.kt
@@ -3,7 +3,9 @@ package com.freekiosk.api
 import fi.iki.elonen.NanoHTTPD
 import org.json.JSONObject
 import org.json.JSONArray
+import android.util.Base64
 import android.util.Log
+import com.freekiosk.camera.CameraStreamManager
 
 /**
  * FreeKiosk REST API Server
@@ -16,7 +18,8 @@ class KioskHttpServer(
     private val statusProvider: () -> JSONObject,
     private val commandHandler: (String, JSONObject?) -> JSONObject,
     private val screenshotProvider: (() -> java.io.InputStream?)? = null,
-    private val cameraPhotoProvider: ((camera: String, quality: Int) -> java.io.InputStream?)? = null
+    private val cameraPhotoProvider: ((camera: String, quality: Int) -> java.io.InputStream?)? = null,
+    private val cameraStreamProvider: ((params: CameraStreamManager.StreamParams) -> CameraStreamManager.StreamResult)? = null
 ) : NanoHTTPD(port) {
 
     companion object {
@@ -44,12 +47,18 @@ class KioskHttpServer(
             }
         }
 
-        // Check authentication if API key is set
+        // Check authentication if API key is set.
+        // The key can be sent either as the X-Api-Key header or as the password of an HTTP
+        // Basic credential (any username): clients such as Home Assistant's MJPEG IP Camera
+        // integration can only send Basic auth.
         if (!apiKey.isNullOrEmpty()) {
             val providedKey = session.headers["x-api-key"]
+                ?: basicAuthPassword(session.headers["authorization"])
             if (providedKey != apiKey) {
-                return jsonError(Response.Status.UNAUTHORIZED, "Invalid or missing API key")
-                    .apply { corsHeaders.forEach { (key, value) -> addHeader(key, value) } }
+                return jsonError(Response.Status.UNAUTHORIZED, "Invalid or missing API key").apply {
+                    addHeader("WWW-Authenticate", "Basic realm=\"FreeKiosk\"")
+                    corsHeaders.forEach { (key, value) -> addHeader(key, value) }
+                }
             }
         }
 
@@ -91,6 +100,9 @@ class KioskHttpServer(
 
                 // Camera photo: GET or POST (query params drive behavior)
                 isGetOrPost && uri == "/api/camera/photo" -> handleCameraPhoto(session)
+
+                // Live MJPEG stream (GET only: the response never ends)
+                method == Method.GET && uri == "/api/camera/stream" -> handleCameraStream(session)
 
                 // POST-only control endpoints requiring a JSON body
                 method == Method.POST && uri == "/api/url" -> handleSetUrl(session)
@@ -174,6 +186,7 @@ class KioskHttpServer(
                     put("/api/health - Health check")
                     put("/api/camera/photo - Take photo (params: camera=front|back, quality=0-100)")
                     put("/api/camera/list - List available cameras")
+                    put("/api/camera/stream - Live MJPEG stream (params: camera, fps, quality, width, rotate)")
                     put("/api/volume - Get current volume {level, maxLevel}")
                     put("/api/location - GPS coordinates (latitude, longitude, accuracy)")
                 })
@@ -637,7 +650,63 @@ class KioskHttpServer(
         return jsonSuccess(result)
     }
 
+    /**
+     * Live MJPEG stream: an endless `multipart/x-mixed-replace` response, one JPEG part per
+     * frame. Consumed by Home Assistant's MJPEG IP Camera integration, ffplay, VLC or a plain
+     * <img> tag. The response only ends when the client disconnects.
+     */
+    private fun handleCameraStream(session: IHTTPSession): Response {
+        val provider = cameraStreamProvider
+            ?: return jsonError(Response.Status.SERVICE_UNAVAILABLE, "Camera streaming not available")
+
+        val params = session.parms ?: emptyMap()
+        val streamParams = CameraStreamManager.StreamParams(
+            facing = params["camera"] ?: "back",
+            fps = (params["fps"]?.toIntOrNull() ?: 10).coerceIn(1, 30),
+            quality = (params["quality"]?.toIntOrNull() ?: 60).coerceIn(1, 100),
+            maxWidth = (params["width"]?.toIntOrNull() ?: 1280).coerceIn(160, 3840),
+            rotate = params["rotate"]?.toIntOrNull()?.let { ((it % 360) + 360) % 360 }
+        )
+
+        Log.i(TAG, "Camera stream request: $streamParams")
+
+        return when (val result = provider(streamParams)) {
+            is CameraStreamManager.StreamResult.Ok -> {
+                val boundary = "frame"
+                newChunkedResponse(
+                    Response.Status.OK,
+                    "multipart/x-mixed-replace; boundary=$boundary",
+                    CameraStreamManager.MjpegInputStream(result.client, boundary)
+                ).apply {
+                    addHeader("Cache-Control", "no-cache, no-store, must-revalidate, private")
+                    addHeader("Pragma", "no-cache")
+                    addHeader("Connection", "close")
+                }
+            }
+            is CameraStreamManager.StreamResult.Error -> {
+                Log.w(TAG, "Camera stream refused: ${result.message}")
+                jsonError(Response.Status.SERVICE_UNAVAILABLE, result.message)
+            }
+        }
+    }
+
     // ==================== Helpers ====================
+
+    /**
+     * Extract the password from an HTTP Basic `Authorization` header. The username is ignored:
+     * the API key is carried in the password field so clients limited to Basic auth can
+     * authenticate.
+     */
+    private fun basicAuthPassword(header: String?): String? {
+        if (header == null || !header.startsWith("Basic ", ignoreCase = true)) return null
+        return try {
+            val decoded = String(Base64.decode(header.substring(6).trim(), Base64.DEFAULT))
+            if (!decoded.contains(':')) null else decoded.substringAfter(':')
+        } catch (e: Exception) {
+            Log.w(TAG, "Malformed Basic authorization header")
+            null
+        }
+    }
 
     private fun parseBody(session: IHTTPSession): JSONObject? {
         return try {

--- a/android/app/src/main/java/com/freekiosk/camera/Camera2MjpegSource.kt
+++ b/android/app/src/main/java/com/freekiosk/camera/Camera2MjpegSource.kt
@@ -48,6 +48,18 @@ class Camera2MjpegSource(
     companion object {
         private const val TAG = "Camera2MjpegSource"
         private const val OPEN_TIMEOUT_SECONDS = 5L
+
+        /** How often frames are compared for movement. */
+        private const val MOTION_ANALYSIS_INTERVAL_MS = 500L
+
+        /** Minimum delay between two motion reports, so one movement wakes the screen once. */
+        private const val MOTION_REPORT_THROTTLE_MS = 2000L
+
+        /** Luma difference above which a sampled pixel counts as changed (0-255). */
+        private const val MOTION_PIXEL_DELTA = 20
+
+        /** Analyse one pixel out of N on each axis — enough to spot a person moving. */
+        private const val MOTION_SAMPLE_STEP = 8
     }
 
     private val frameIntervalMs = 1000L / targetFps.coerceIn(1, 30)
@@ -72,6 +84,21 @@ class Camera2MjpegSource(
      * motion detection). The stream cannot recover on its own and must be torn down.
      */
     var onStreamLost: (() -> Unit)? = null
+
+    /**
+     * Called when movement is seen between two frames. Deriving motion from the stream is what
+     * allows a single sensor to serve both a live feed and wake-on-motion: a second camera
+     * client is impossible, but the frames are already decoded here.
+     *
+     * Set [motionThreshold] to the ratio of changed pixels that counts as movement.
+     */
+    var onMotionDetected: (() -> Unit)? = null
+    var motionThreshold: Double = 0.08
+
+    /** Luma samples of the previous analysed frame. */
+    private var previousLuma: IntArray? = null
+    private var lastMotionAnalysisAt = 0L
+    private var lastMotionReportedAt = 0L
 
     /**
      * Open the camera and start delivering JPEG frames.
@@ -307,6 +334,9 @@ class Camera2MjpegSource(
         var height = image.height
         var nv21 = yuv420ToNv21(image)
 
+        // Movement is measured on the untouched luma plane, before any rotation
+        if (onMotionDetected != null) analyseMotion(nv21, width, height)
+
         when (rotationDegrees) {
             90 -> {
                 nv21 = rotateNv21By90(nv21, width, height)
@@ -326,6 +356,45 @@ class Camera2MjpegSource(
         } else {
             Log.w(TAG, "JPEG compression failed")
             null
+        }
+    }
+
+    /**
+     * Compare the luma plane with the previous analysed frame and report movement when enough
+     * sampled pixels changed. Sampling one pixel out of [MOTION_SAMPLE_STEP] on each axis keeps
+     * this well under a millisecond, next to the ~10 ms the JPEG encoding already costs.
+     */
+    private fun analyseMotion(nv21: ByteArray, width: Int, height: Int) {
+        val now = System.currentTimeMillis()
+        if (now - lastMotionAnalysisAt < MOTION_ANALYSIS_INTERVAL_MS) return
+        lastMotionAnalysisAt = now
+
+        val columns = width / MOTION_SAMPLE_STEP
+        val rows = height / MOTION_SAMPLE_STEP
+        val samples = IntArray(columns * rows)
+        var index = 0
+        for (row in 0 until rows) {
+            val rowOffset = row * MOTION_SAMPLE_STEP * width
+            for (col in 0 until columns) {
+                samples[index++] = nv21[rowOffset + col * MOTION_SAMPLE_STEP].toInt() and 0xFF
+            }
+        }
+
+        val previous = previousLuma
+        previousLuma = samples
+        if (previous == null || previous.size != samples.size) return
+
+        var changed = 0
+        for (i in samples.indices) {
+            if (kotlin.math.abs(samples[i] - previous[i]) > MOTION_PIXEL_DELTA) changed++
+        }
+        val ratio = changed.toDouble() / samples.size
+        Log.d(TAG, "Motion ratio=%.4f (threshold=%.3f, samples=%d)".format(ratio, motionThreshold, samples.size))
+
+        if (ratio >= motionThreshold && now - lastMotionReportedAt >= MOTION_REPORT_THROTTLE_MS) {
+            lastMotionReportedAt = now
+            Log.i(TAG, "Motion detected in stream (ratio=%.3f, threshold=%.3f)".format(ratio, motionThreshold))
+            onMotionDetected?.invoke()
         }
     }
 

--- a/android/app/src/main/java/com/freekiosk/camera/Camera2MjpegSource.kt
+++ b/android/app/src/main/java/com/freekiosk/camera/Camera2MjpegSource.kt
@@ -55,11 +55,27 @@ class Camera2MjpegSource(
         /** Minimum delay between two motion reports, so one movement wakes the screen once. */
         private const val MOTION_REPORT_THROTTLE_MS = 2000L
 
-        /** Luma difference above which a sampled pixel counts as changed (0-255). */
+        /**
+         * Luma difference above which a sampled pixel counts as changed (0-255).
+         *
+         * MotionDetectionModule uses the equivalent of 10, but on photos downscaled by
+         * inSampleSize=4, which averages out sensor noise. Raw stream frames have no such
+         * smoothing: measured on a Xiaomi tablet, a still scene sits at a 0.05-0.083 changed
+         * ratio with 10 — level with the "medium" sensitivity threshold — against 0.008-0.012
+         * with 20, which leaves an 8x margin. Do not "align" this with the JS detector without
+         * measuring the noise floor again.
+         */
         private const val MOTION_PIXEL_DELTA = 20
 
         /** Analyse one pixel out of N on each axis — enough to spot a person moving. */
         private const val MOTION_SAMPLE_STEP = 8
+
+        /**
+         * Analyses skipped after the camera opens, while auto-exposure settles. The regular
+         * detector does the same with its first frames; without it, the exposure ramp reads as
+         * movement.
+         */
+        private const val MOTION_WARMUP_ANALYSES = 2
     }
 
     private val frameIntervalMs = 1000L / targetFps.coerceIn(1, 30)
@@ -99,6 +115,7 @@ class Camera2MjpegSource(
     private var previousLuma: IntArray? = null
     private var lastMotionAnalysisAt = 0L
     private var lastMotionReportedAt = 0L
+    private var warmupAnalysesLeft = MOTION_WARMUP_ANALYSES
 
     /**
      * Open the camera and start delivering JPEG frames.
@@ -383,6 +400,12 @@ class Camera2MjpegSource(
         val previous = previousLuma
         previousLuma = samples
         if (previous == null || previous.size != samples.size) return
+
+        if (warmupAnalysesLeft > 0) {
+            warmupAnalysesLeft--
+            Log.d(TAG, "Motion analysis warming up ($warmupAnalysesLeft left)")
+            return
+        }
 
         var changed = 0
         for (i in samples.indices) {

--- a/android/app/src/main/java/com/freekiosk/camera/Camera2MjpegSource.kt
+++ b/android/app/src/main/java/com/freekiosk/camera/Camera2MjpegSource.kt
@@ -1,0 +1,403 @@
+package com.freekiosk.camera
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.graphics.ImageFormat
+import android.graphics.Rect
+import android.graphics.YuvImage
+import android.hardware.camera2.CameraAccessException
+import android.hardware.camera2.CameraCaptureSession
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.CameraDevice
+import android.hardware.camera2.CameraManager
+import android.hardware.camera2.CaptureRequest
+import android.hardware.display.DisplayManager
+import android.media.Image
+import android.media.ImageReader
+import android.os.Handler
+import android.os.HandlerThread
+import android.util.Log
+import android.util.Size
+import android.view.Display
+import android.view.Surface
+import androidx.core.content.ContextCompat
+import java.io.ByteArrayOutputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Continuous JPEG frame source backed by Camera2.
+ *
+ * Runs a repeating preview request on a YUV_420_888 [ImageReader] and compresses each frame
+ * with [YuvImage]. A repeating JPEG request would be simpler but is unreliable across devices,
+ * and would re-run the full still-capture pipeline for every frame.
+ *
+ * Frames are delivered on the camera background thread; consumers must not block in [onFrame].
+ */
+class Camera2MjpegSource(
+    private val context: Context,
+    private val facing: String,
+    targetFps: Int,
+    quality: Int,
+    private val maxWidth: Int,
+    /** Extra clockwise rotation in degrees (0/90/180/270), or null to derive it from the sensor. */
+    private val rotationOverride: Int?
+) {
+
+    companion object {
+        private const val TAG = "Camera2MjpegSource"
+        private const val OPEN_TIMEOUT_SECONDS = 5L
+    }
+
+    private val frameIntervalMs = 1000L / targetFps.coerceIn(1, 30)
+    private val jpegQuality = quality.coerceIn(1, 100)
+
+    private var handlerThread: HandlerThread? = null
+    private var handler: Handler? = null
+    private var cameraDevice: CameraDevice? = null
+    private var captureSession: CameraCaptureSession? = null
+    private var imageReader: ImageReader? = null
+
+    @Volatile private var running = false
+    @Volatile private var lastFrameAt = 0L
+    private var rotationDegrees = 0
+
+    /** Size actually used for capture, available once [start] succeeded. */
+    var captureSize: Size? = null
+        private set
+
+    /**
+     * Open the camera and start delivering JPEG frames.
+     *
+     * @return true when the stream is running, false when the camera could not be opened
+     *         (missing permission, no such camera, or another client holds it).
+     */
+    fun start(onFrame: (ByteArray) -> Unit): Boolean {
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA)
+            != PackageManager.PERMISSION_GRANTED
+        ) {
+            Log.e(TAG, "Camera permission not granted")
+            return false
+        }
+
+        val cameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+        val cameraId = findCameraId(cameraManager, facing)
+        if (cameraId == null) {
+            Log.e(TAG, "No $facing camera on this device")
+            return false
+        }
+
+        val thread = HandlerThread("MjpegCameraThread").apply { start() }
+        val threadHandler = Handler(thread.looper)
+        handlerThread = thread
+        handler = threadHandler
+
+        return try {
+            val characteristics = cameraManager.getCameraCharacteristics(cameraId)
+            rotationDegrees = rotationOverride ?: computeRotation(characteristics)
+
+            val size = selectSize(characteristics)
+            captureSize = size
+            Log.i(TAG, "Starting $facing stream at ${size.width}x${size.height}, rotation=$rotationDegrees")
+
+            val reader = ImageReader.newInstance(size.width, size.height, ImageFormat.YUV_420_888, 3)
+            imageReader = reader
+            reader.setOnImageAvailableListener({ r ->
+                val image = r.acquireLatestImage() ?: return@setOnImageAvailableListener
+                try {
+                    if (!running) return@setOnImageAvailableListener
+                    val now = System.currentTimeMillis()
+                    if (now - lastFrameAt < frameIntervalMs) return@setOnImageAvailableListener
+                    lastFrameAt = now
+                    encodeFrame(image)?.let(onFrame)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Frame encoding failed: ${e.message}")
+                } finally {
+                    image.close()
+                }
+            }, threadHandler)
+
+            if (!openCameraAndSession(cameraManager, cameraId, reader, threadHandler)) {
+                stop()
+                return false
+            }
+
+            running = true
+            true
+        } catch (e: SecurityException) {
+            Log.e(TAG, "Camera permission denied: ${e.message}")
+            stop()
+            false
+        } catch (e: CameraAccessException) {
+            Log.e(TAG, "Camera access error: ${e.message}")
+            stop()
+            false
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to start stream: ${e.message}", e)
+            stop()
+            false
+        }
+    }
+
+    /** Stop the repeating request and release the camera. */
+    fun stop() {
+        running = false
+        try {
+            captureSession?.stopRepeating()
+        } catch (e: Exception) {
+            Log.d(TAG, "stopRepeating failed (already closed): ${e.message}")
+        }
+        try {
+            captureSession?.close()
+            cameraDevice?.close()
+            imageReader?.close()
+        } catch (e: Exception) {
+            Log.w(TAG, "Error while releasing camera: ${e.message}")
+        }
+        captureSession = null
+        cameraDevice = null
+        imageReader = null
+        handlerThread?.quitSafely()
+        handlerThread = null
+        handler = null
+        Log.i(TAG, "Stream stopped ($facing)")
+    }
+
+    // ==================== Camera setup ====================
+
+    private fun openCameraAndSession(
+        cameraManager: CameraManager,
+        cameraId: String,
+        reader: ImageReader,
+        threadHandler: Handler
+    ): Boolean {
+        val openLatch = CountDownLatch(1)
+        var opened: CameraDevice? = null
+        var openFailed = false
+
+        cameraManager.openCamera(cameraId, object : CameraDevice.StateCallback() {
+            override fun onOpened(camera: CameraDevice) {
+                opened = camera
+                openLatch.countDown()
+            }
+
+            override fun onDisconnected(camera: CameraDevice) {
+                Log.w(TAG, "Camera disconnected")
+                camera.close()
+                openFailed = true
+                openLatch.countDown()
+            }
+
+            override fun onError(camera: CameraDevice, error: Int) {
+                // error 1 = ERROR_CAMERA_IN_USE, typically motion detection holding the sensor
+                Log.e(TAG, "Camera error $error while opening")
+                camera.close()
+                openFailed = true
+                openLatch.countDown()
+            }
+        }, threadHandler)
+
+        if (!openLatch.await(OPEN_TIMEOUT_SECONDS, TimeUnit.SECONDS) || openFailed) {
+            Log.e(TAG, "Could not open camera (timeout or in use)")
+            return false
+        }
+        val camera = opened ?: return false
+        cameraDevice = camera
+
+        val sessionLatch = CountDownLatch(1)
+        var session: CameraCaptureSession? = null
+
+        camera.createCaptureSession(listOf(reader.surface), object : CameraCaptureSession.StateCallback() {
+            override fun onConfigured(configured: CameraCaptureSession) {
+                session = configured
+                sessionLatch.countDown()
+            }
+
+            override fun onConfigureFailed(configured: CameraCaptureSession) {
+                Log.e(TAG, "Capture session configuration failed")
+                sessionLatch.countDown()
+            }
+        }, threadHandler)
+
+        if (!sessionLatch.await(OPEN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            Log.e(TAG, "Timeout configuring capture session")
+            return false
+        }
+        val configured = session ?: return false
+        captureSession = configured
+
+        val request = camera.createCaptureRequest(CameraDevice.TEMPLATE_PREVIEW).apply {
+            addTarget(reader.surface)
+            set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE)
+            set(CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON)
+        }.build()
+
+        configured.setRepeatingRequest(request, null, threadHandler)
+        return true
+    }
+
+    private fun findCameraId(cameraManager: CameraManager, facing: String): String? {
+        val target = when (facing.lowercase()) {
+            "front" -> CameraCharacteristics.LENS_FACING_FRONT
+            else -> CameraCharacteristics.LENS_FACING_BACK
+        }
+        for (id in cameraManager.cameraIdList) {
+            val lensFacing = cameraManager.getCameraCharacteristics(id)
+                .get(CameraCharacteristics.LENS_FACING)
+            if (lensFacing == target) return id
+        }
+        return null
+    }
+
+    /** Pick the output size closest to [maxWidth] without exceeding it when possible. */
+    private fun selectSize(characteristics: CameraCharacteristics): Size {
+        val sizes = characteristics
+            .get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP)
+            ?.getOutputSizes(ImageFormat.YUV_420_888)
+            ?: emptyArray()
+
+        if (sizes.isEmpty()) return Size(640, 480)
+
+        val within = sizes.filter { it.width <= maxWidth }
+        return (within.maxByOrNull { it.width * it.height }
+            ?: sizes.minByOrNull { it.width * it.height })!!
+    }
+
+    /**
+     * Clockwise rotation needed to display frames upright, derived from the sensor mounting and
+     * the current display rotation. MJPEG viewers ignore EXIF, so frames are rotated in pixels.
+     */
+    private fun computeRotation(characteristics: CameraCharacteristics): Int {
+        val sensorOrientation = characteristics.get(CameraCharacteristics.SENSOR_ORIENTATION) ?: 0
+        val facingFront =
+            characteristics.get(CameraCharacteristics.LENS_FACING) == CameraCharacteristics.LENS_FACING_FRONT
+
+        val displayRotationDegrees = try {
+            val displayManager = context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+            when (displayManager.getDisplay(Display.DEFAULT_DISPLAY)?.rotation) {
+                Surface.ROTATION_90 -> 90
+                Surface.ROTATION_180 -> 180
+                Surface.ROTATION_270 -> 270
+                else -> 0
+            }
+        } catch (e: Exception) {
+            0
+        }
+
+        var deviceOrientation = (360 - displayRotationDegrees) % 360
+        if (facingFront) deviceOrientation = -deviceOrientation
+        return (sensorOrientation + deviceOrientation + 360) % 360
+    }
+
+    // ==================== Frame encoding ====================
+
+    private fun encodeFrame(image: Image): ByteArray? {
+        var width = image.width
+        var height = image.height
+        var nv21 = yuv420ToNv21(image)
+
+        when (rotationDegrees) {
+            90 -> {
+                nv21 = rotateNv21By90(nv21, width, height)
+                val swap = width; width = height; height = swap
+            }
+            180 -> nv21 = rotateNv21By180(nv21, width, height)
+            270 -> {
+                nv21 = rotateNv21By180(rotateNv21By90(nv21, width, height), height, width)
+                val swap = width; width = height; height = swap
+            }
+        }
+
+        val out = ByteArrayOutputStream()
+        val yuvImage = YuvImage(nv21, ImageFormat.NV21, width, height, null)
+        return if (yuvImage.compressToJpeg(Rect(0, 0, width, height), jpegQuality, out)) {
+            out.toByteArray()
+        } else {
+            Log.w(TAG, "JPEG compression failed")
+            null
+        }
+    }
+
+    /** Copy a YUV_420_888 image into a contiguous NV21 buffer, honouring plane strides. */
+    private fun yuv420ToNv21(image: Image): ByteArray {
+        val width = image.width
+        val height = image.height
+        val ySize = width * height
+        val nv21 = ByteArray(ySize + ySize / 2)
+
+        val yPlane = image.planes[0]
+        val uPlane = image.planes[1]
+        val vPlane = image.planes[2]
+
+        // Luma, row by row (rowStride can be larger than the width)
+        val yBuffer = yPlane.buffer
+        var offset = 0
+        if (yPlane.rowStride == width) {
+            yBuffer.get(nv21, 0, ySize)
+            offset = ySize
+        } else {
+            for (row in 0 until height) {
+                yBuffer.position(row * yPlane.rowStride)
+                yBuffer.get(nv21, offset, width)
+                offset += width
+            }
+        }
+
+        // Chroma, interleaved as V,U (NV21)
+        val uBuffer = uPlane.buffer
+        val vBuffer = vPlane.buffer
+        val uvRowStride = uPlane.rowStride
+        val uvPixelStride = uPlane.pixelStride
+        for (row in 0 until height / 2) {
+            for (col in 0 until width / 2) {
+                val uvIndex = row * uvRowStride + col * uvPixelStride
+                nv21[offset++] = vBuffer.get(uvIndex)
+                nv21[offset++] = uBuffer.get(uvIndex)
+            }
+        }
+        return nv21
+    }
+
+    private fun rotateNv21By90(input: ByteArray, width: Int, height: Int): ByteArray {
+        val output = ByteArray(input.size)
+        val frameSize = width * height
+
+        var i = 0
+        for (x in 0 until width) {
+            for (y in height - 1 downTo 0) {
+                output[i++] = input[y * width + x]
+            }
+        }
+
+        i = input.size - 1
+        var x = width - 1
+        while (x > 0) {
+            for (y in 0 until height / 2) {
+                output[i--] = input[frameSize + y * width + x]
+                output[i--] = input[frameSize + y * width + (x - 1)]
+            }
+            x -= 2
+        }
+        return output
+    }
+
+    private fun rotateNv21By180(input: ByteArray, width: Int, height: Int): ByteArray {
+        val output = ByteArray(input.size)
+        val frameSize = width * height
+
+        var i = 0
+        for (position in frameSize - 1 downTo 0) {
+            output[i++] = input[position]
+        }
+
+        i = output.size - 1
+        var position = frameSize
+        while (position < input.size) {
+            output[i--] = input[position + 1]
+            output[i--] = input[position]
+            position += 2
+        }
+        return output
+    }
+}

--- a/android/app/src/main/java/com/freekiosk/camera/Camera2MjpegSource.kt
+++ b/android/app/src/main/java/com/freekiosk/camera/Camera2MjpegSource.kt
@@ -68,6 +68,12 @@ class Camera2MjpegSource(
         private set
 
     /**
+     * Called when the camera is taken away while streaming (another client opened it, e.g.
+     * motion detection). The stream cannot recover on its own and must be torn down.
+     */
+    var onStreamLost: (() -> Unit)? = null
+
+    /**
      * Open the camera and start delivering JPEG frames.
      *
      * @return true when the stream is running, false when the camera could not be opened
@@ -187,14 +193,18 @@ class Camera2MjpegSource(
                 camera.close()
                 openFailed = true
                 openLatch.countDown()
+                // Taken away mid-stream: tell the manager instead of serving a dead stream
+                // until the frame timeout expires.
+                if (running) onStreamLost?.invoke()
             }
 
             override fun onError(camera: CameraDevice, error: Int) {
                 // error 1 = ERROR_CAMERA_IN_USE, typically motion detection holding the sensor
-                Log.e(TAG, "Camera error $error while opening")
+                Log.e(TAG, "Camera error $error")
                 camera.close()
                 openFailed = true
                 openLatch.countDown()
+                if (running) onStreamLost?.invoke()
             }
         }, threadHandler)
 

--- a/android/app/src/main/java/com/freekiosk/camera/Camera2MjpegSource.kt
+++ b/android/app/src/main/java/com/freekiosk/camera/Camera2MjpegSource.kt
@@ -403,7 +403,6 @@ class Camera2MjpegSource(
 
         if (warmupAnalysesLeft > 0) {
             warmupAnalysesLeft--
-            Log.d(TAG, "Motion analysis warming up ($warmupAnalysesLeft left)")
             return
         }
 
@@ -412,7 +411,6 @@ class Camera2MjpegSource(
             if (kotlin.math.abs(samples[i] - previous[i]) > MOTION_PIXEL_DELTA) changed++
         }
         val ratio = changed.toDouble() / samples.size
-        Log.d(TAG, "Motion ratio=%.4f (threshold=%.3f, samples=%d)".format(ratio, motionThreshold, samples.size))
 
         if (ratio >= motionThreshold && now - lastMotionReportedAt >= MOTION_REPORT_THROTTLE_MS) {
             lastMotionReportedAt = now

--- a/android/app/src/main/java/com/freekiosk/camera/CameraStreamManager.kt
+++ b/android/app/src/main/java/com/freekiosk/camera/CameraStreamManager.kt
@@ -1,0 +1,243 @@
+package com.freekiosk.camera
+
+import android.content.Context
+import android.util.Log
+import java.io.InputStream
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.TimeUnit
+
+/**
+ * Owns the single camera stream shared by all MJPEG clients.
+ *
+ * The camera is opened when the first client connects and released when the last one leaves,
+ * so an idle kiosk never holds the sensor. Each client gets its own small frame queue with
+ * drop-oldest semantics: a slow reader falls behind on frames instead of stalling the capture
+ * loop for everyone.
+ */
+class CameraStreamManager(private val context: Context) {
+
+    companion object {
+        private const val TAG = "CameraStreamManager"
+
+        /** Concurrent viewers. Each one costs a socket and a JPEG copy per frame. */
+        private const val MAX_CLIENTS = 2
+
+        /** Frames buffered per client before the oldest is dropped. */
+        private const val QUEUE_CAPACITY = 2
+
+        /** Give up on a stream that received no frame for this long. */
+        private const val FRAME_TIMEOUT_MS = 10_000L
+    }
+
+    data class StreamParams(
+        val facing: String,
+        val fps: Int,
+        val quality: Int,
+        val maxWidth: Int,
+        val rotate: Int?
+    )
+
+    sealed class StreamResult {
+        data class Ok(val client: StreamClient) : StreamResult()
+        data class Error(val message: String) : StreamResult()
+    }
+
+    /**
+     * Called before opening the camera; returns how long to wait (ms) for another component
+     * to release it. Used to let motion detection stop first.
+     */
+    var prepareCamera: (() -> Long)? = null
+
+    /** Called after the camera has been released, so motion detection can resume. */
+    var releaseCamera: (() -> Unit)? = null
+
+    private val clients = CopyOnWriteArrayList<StreamClient>()
+    private var source: Camera2MjpegSource? = null
+    private var activeParams: StreamParams? = null
+    private val lock = Any()
+
+    /** Whether a stream is currently running (used to report state to JS). */
+    val isStreaming: Boolean
+        get() = source != null
+
+    fun openClient(params: StreamParams): StreamResult {
+        synchronized(lock) {
+            if (clients.size >= MAX_CLIENTS) {
+                return StreamResult.Error("Too many stream clients (max $MAX_CLIENTS)")
+            }
+
+            if (source == null) {
+                if (!startSource(params)) {
+                    return StreamResult.Error(
+                        "Camera unavailable. It is likely in use by motion detection."
+                    )
+                }
+                activeParams = params
+            } else if (activeParams?.facing != params.facing) {
+                return StreamResult.Error(
+                    "Another client is already streaming the ${activeParams?.facing} camera"
+                )
+            }
+
+            val client = StreamClient()
+            clients.add(client)
+            Log.i(TAG, "Client connected (${clients.size}/$MAX_CLIENTS)")
+            return StreamResult.Ok(client)
+        }
+    }
+
+    private fun startSource(params: StreamParams): Boolean {
+        val waitMs = try {
+            prepareCamera?.invoke() ?: 0L
+        } catch (e: Exception) {
+            Log.w(TAG, "prepareCamera failed: ${e.message}")
+            0L
+        }
+        if (waitMs > 0) {
+            Log.d(TAG, "Waiting ${waitMs}ms for the camera to be released")
+            try {
+                Thread.sleep(waitMs)
+            } catch (e: InterruptedException) {
+                Thread.currentThread().interrupt()
+            }
+        }
+
+        val newSource = Camera2MjpegSource(
+            context = context,
+            facing = params.facing,
+            targetFps = params.fps,
+            quality = params.quality,
+            maxWidth = params.maxWidth,
+            rotationOverride = params.rotate
+        )
+
+        if (!newSource.start { frame -> dispatchFrame(frame) }) {
+            releaseCamera?.invoke()
+            return false
+        }
+
+        source = newSource
+        Log.i(TAG, "Camera stream started (${params.facing}, ${params.fps} fps)")
+        return true
+    }
+
+    private fun dispatchFrame(frame: ByteArray) {
+        for (client in clients) {
+            client.offer(frame)
+        }
+    }
+
+    private fun closeClient(client: StreamClient) {
+        synchronized(lock) {
+            if (!clients.remove(client)) return
+            Log.i(TAG, "Client disconnected (${clients.size} left)")
+            if (clients.isEmpty()) {
+                source?.stop()
+                source = null
+                activeParams = null
+                try {
+                    releaseCamera?.invoke()
+                } catch (e: Exception) {
+                    Log.w(TAG, "releaseCamera failed: ${e.message}")
+                }
+                Log.i(TAG, "No client left, camera released")
+            }
+        }
+    }
+
+    /** Stop everything, e.g. when the HTTP server shuts down. */
+    fun stopAll() {
+        synchronized(lock) {
+            clients.forEach { it.markClosed() }
+            clients.clear()
+            source?.stop()
+            source = null
+            activeParams = null
+        }
+    }
+
+    /**
+     * One connected viewer. Frames are pushed by the camera thread and pulled by the HTTP
+     * worker thread serving the multipart response.
+     */
+    inner class StreamClient {
+        private val queue = ArrayBlockingQueue<ByteArray>(QUEUE_CAPACITY)
+        @Volatile private var closed = false
+
+        internal fun offer(frame: ByteArray) {
+            if (closed) return
+            // Drop the oldest frame rather than blocking the camera thread
+            if (!queue.offer(frame)) {
+                queue.poll()
+                queue.offer(frame)
+            }
+        }
+
+        internal fun markClosed() {
+            closed = true
+        }
+
+        /** Next frame, or null when the stream ended or timed out. */
+        fun nextFrame(): ByteArray? {
+            if (closed) return null
+            return queue.poll(FRAME_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        }
+
+        fun close() {
+            if (closed) return
+            closed = true
+            queue.clear()
+            closeClient(this)
+        }
+    }
+
+    /**
+     * Body of a `multipart/x-mixed-replace` response: an endless sequence of JPEG parts.
+     * Closing the stream (client disconnect, server shutdown) releases the underlying client.
+     */
+    class MjpegInputStream(
+        private val client: StreamClient,
+        private val boundary: String
+    ) : InputStream() {
+
+        private var chunk: ByteArray = ByteArray(0)
+        private var position = 0
+
+        private fun ensureChunk(): Boolean {
+            if (position < chunk.size) return true
+            val frame = client.nextFrame() ?: return false
+            val header = (
+                "--$boundary\r\n" +
+                    "Content-Type: image/jpeg\r\n" +
+                    "Content-Length: ${frame.size}\r\n\r\n"
+                ).toByteArray()
+            chunk = ByteArray(header.size + frame.size + 2)
+            System.arraycopy(header, 0, chunk, 0, header.size)
+            System.arraycopy(frame, 0, chunk, header.size, frame.size)
+            chunk[chunk.size - 2] = '\r'.code.toByte()
+            chunk[chunk.size - 1] = '\n'.code.toByte()
+            position = 0
+            return true
+        }
+
+        override fun read(): Int {
+            if (!ensureChunk()) return -1
+            return chunk[position++].toInt() and 0xFF
+        }
+
+        override fun read(b: ByteArray, off: Int, len: Int): Int {
+            if (!ensureChunk()) return -1
+            val available = chunk.size - position
+            val count = minOf(len, available)
+            System.arraycopy(chunk, position, b, off, count)
+            position += count
+            return count
+        }
+
+        override fun close() {
+            client.close()
+            super.close()
+        }
+    }
+}

--- a/android/app/src/main/java/com/freekiosk/camera/CameraStreamManager.kt
+++ b/android/app/src/main/java/com/freekiosk/camera/CameraStreamManager.kt
@@ -28,6 +28,14 @@ class CameraStreamManager(private val context: Context) {
 
         /** Give up on a stream that received no frame for this long. */
         private const val FRAME_TIMEOUT_MS = 10_000L
+
+        /**
+         * Attempts to open the camera when another component (motion detection) has just been
+         * asked to release it. Retrying is more reliable than guessing a single delay that
+         * would fit every device.
+         */
+        private const val OPEN_ATTEMPTS_WHEN_BUSY = 3
+        private const val RETRY_DELAY_MS = 700L
     }
 
     data class StreamParams(
@@ -96,30 +104,45 @@ class CameraStreamManager(private val context: Context) {
         }
         if (waitMs > 0) {
             Log.d(TAG, "Waiting ${waitMs}ms for the camera to be released")
-            try {
-                Thread.sleep(waitMs)
-            } catch (e: InterruptedException) {
-                Thread.currentThread().interrupt()
+            sleepQuietly(waitMs)
+        }
+
+        // When something else was holding the camera, releasing it is asynchronous: retry a
+        // few times rather than failing on a single unlucky attempt.
+        val attempts = if (waitMs > 0) OPEN_ATTEMPTS_WHEN_BUSY else 1
+        for (attempt in 1..attempts) {
+            if (attempt > 1) {
+                Log.d(TAG, "Camera still busy, retrying ($attempt/$attempts)")
+                sleepQuietly(RETRY_DELAY_MS)
+            }
+
+            val newSource = Camera2MjpegSource(
+                context = context,
+                facing = params.facing,
+                targetFps = params.fps,
+                quality = params.quality,
+                maxWidth = params.maxWidth,
+                rotationOverride = params.rotate
+            )
+
+            if (newSource.start { frame -> dispatchFrame(frame) }) {
+                source = newSource
+                Log.i(TAG, "Camera stream started (${params.facing}, ${params.fps} fps)")
+                return true
             }
         }
 
-        val newSource = Camera2MjpegSource(
-            context = context,
-            facing = params.facing,
-            targetFps = params.fps,
-            quality = params.quality,
-            maxWidth = params.maxWidth,
-            rotationOverride = params.rotate
-        )
+        Log.e(TAG, "Could not open the camera after $attempts attempt(s)")
+        releaseCamera?.invoke()
+        return false
+    }
 
-        if (!newSource.start { frame -> dispatchFrame(frame) }) {
-            releaseCamera?.invoke()
-            return false
+    private fun sleepQuietly(millis: Long) {
+        try {
+            Thread.sleep(millis)
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
         }
-
-        source = newSource
-        Log.i(TAG, "Camera stream started (${params.facing}, ${params.fps} fps)")
-        return true
     }
 
     private fun dispatchFrame(frame: ByteArray) {

--- a/android/app/src/main/java/com/freekiosk/camera/CameraStreamManager.kt
+++ b/android/app/src/main/java/com/freekiosk/camera/CameraStreamManager.kt
@@ -125,6 +125,8 @@ class CameraStreamManager(private val context: Context) {
                 rotationOverride = params.rotate
             )
 
+            newSource.onStreamLost = { handleStreamLost() }
+
             if (newSource.start { frame -> dispatchFrame(frame) }) {
                 source = newSource
                 Log.i(TAG, "Camera stream started (${params.facing}, ${params.fps} fps)")
@@ -165,6 +167,28 @@ class CameraStreamManager(private val context: Context) {
                     Log.w(TAG, "releaseCamera failed: ${e.message}")
                 }
                 Log.i(TAG, "No client left, camera released")
+            }
+        }
+    }
+
+    /**
+     * The camera was taken away mid-stream (another client opened it). End every viewer's
+     * response right away and hand the sensor back, rather than letting clients hang until
+     * their frame timeout.
+     */
+    private fun handleStreamLost() {
+        synchronized(lock) {
+            if (source == null) return
+            Log.w(TAG, "Camera lost to another client, ending ${clients.size} stream(s)")
+            clients.forEach { it.markClosed() }
+            clients.clear()
+            source?.stop()
+            source = null
+            activeParams = null
+            try {
+                releaseCamera?.invoke()
+            } catch (e: Exception) {
+                Log.w(TAG, "releaseCamera failed: ${e.message}")
             }
         }
     }

--- a/android/app/src/main/java/com/freekiosk/camera/CameraStreamManager.kt
+++ b/android/app/src/main/java/com/freekiosk/camera/CameraStreamManager.kt
@@ -60,6 +60,15 @@ class CameraStreamManager(private val context: Context) {
     /** Called after the camera has been released, so motion detection can resume. */
     var releaseCamera: (() -> Unit)? = null
 
+    /**
+     * Called when movement is seen in the stream. While a stream runs it replaces the regular
+     * motion detection, which cannot open the camera at the same time.
+     */
+    var onMotionDetected: (() -> Unit)? = null
+
+    /** Ratio of changed pixels counting as movement, from the app's sensitivity setting. */
+    var motionThreshold: Double = 0.08
+
     private val clients = CopyOnWriteArrayList<StreamClient>()
     private var source: Camera2MjpegSource? = null
     private var activeParams: StreamParams? = null
@@ -126,6 +135,8 @@ class CameraStreamManager(private val context: Context) {
             )
 
             newSource.onStreamLost = { handleStreamLost() }
+            newSource.motionThreshold = motionThreshold
+            onMotionDetected?.let { callback -> newSource.onMotionDetected = callback }
 
             if (newSource.start { frame -> dispatchFrame(frame) }) {
                 source = newSource

--- a/android/app/src/main/java/com/freekiosk/camera/CameraStreamManager.kt
+++ b/android/app/src/main/java/com/freekiosk/camera/CameraStreamManager.kt
@@ -69,6 +69,19 @@ class CameraStreamManager(private val context: Context) {
     /** Ratio of changed pixels counting as movement, from the app's sensitivity setting. */
     var motionThreshold: Double = 0.08
 
+    /**
+     * Streaming is opt-in: the endpoint stays refused until the app pushes the setting.
+     * Defaults below are used for any parameter the request does not specify.
+     */
+    @Volatile var enabled: Boolean = false
+    @Volatile var defaultFacing: String = "front"
+    @Volatile var defaultFps: Int = 10
+    @Volatile var defaultQuality: Int = 60
+    @Volatile var defaultWidth: Int = 1280
+
+    /** Extra clockwise rotation, or null to derive it from the sensor. */
+    @Volatile var defaultRotate: Int? = null
+
     private val clients = CopyOnWriteArrayList<StreamClient>()
     private var source: Camera2MjpegSource? = null
     private var activeParams: StreamParams? = null
@@ -80,6 +93,10 @@ class CameraStreamManager(private val context: Context) {
 
     fun openClient(params: StreamParams): StreamResult {
         synchronized(lock) {
+            if (!enabled) {
+                return StreamResult.Error("Camera streaming is disabled in settings")
+            }
+
             if (clients.size >= MAX_CLIENTS) {
                 return StreamResult.Error("Too many stream clients (max $MAX_CLIENTS)")
             }

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -102,7 +102,7 @@ camera:
 ```
 
 > [!NOTE]
-> Wake-on-motion keeps working while the stream runs: a camera accepts a single client, so movement is measured on the stream's own frames instead. Nothing to configure.
+> Wake-on-motion keeps working while the stream runs: a camera accepts a single client, so movement is measured on the stream's own frames instead. Nothing to configure, and the sensitivity you chose still applies. The only difference in practice is that a colour change at constant brightness goes unnoticed, since only the luma plane is compared.
 
 > [!TIP]
 > MJPEG is not free: budget ~5 Mbit/s and about two thirds of a CPU core at 1280×960, quality 60, 10 fps. For plain monitoring, 5 fps and quality 50 look nearly identical for half the cost. For still images only, the [MQTT camera entities](MQTT#-images-screenshot--camera) are far cheaper.

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -70,10 +70,42 @@ curl -X POST -H "X-Api-Key: your-key" \
 
 # Take screenshot
 curl -H "X-Api-Key: your-key" http://tablet-ip:8080/api/screenshot -o screenshot.png
+
+# Watch the live camera stream (enable it first in Settings > Advanced > REST API)
+ffplay "http://tablet-ip:8080/api/camera/stream?camera=front&fps=10"
 ```
 
 > [!TIP]
 > See the complete [REST API Reference](REST-API) for all endpoints.
+
+### Using the Tablet as a Camera
+
+A wall-mounted tablet is often the only device already installed in a room. With **Live Camera Stream** enabled, its camera shows up in Home Assistant through the *MJPEG IP Camera* integration:
+
+
+
+| Field | Value |
+|---|---|
+| **MJPEG URL** | `http://TABLET_IP:8080/api/camera/stream?camera=front&fps=10` |
+| **Still image URL** | `http://TABLET_IP:8080/api/camera/photo?camera=front` |
+| **Username / Password** | anything / your API key, if one is set |
+
+
+
+```yaml
+# Or in configuration.yaml
+camera:
+  - platform: mjpeg
+    name: Lobby Kiosk
+    mjpeg_url: http://TABLET_IP:8080/api/camera/stream?camera=front&fps=10
+    still_image_url: http://TABLET_IP:8080/api/camera/photo?camera=front
+```
+
+> [!NOTE]
+> Wake-on-motion keeps working while the stream runs: a camera accepts a single client, so movement is measured on the stream's own frames instead. Nothing to configure.
+
+> [!TIP]
+> MJPEG is not free: budget ~5 Mbit/s and about two thirds of a CPU core at 1280×960, quality 60, 10 fps. For plain monitoring, 5 fps and quality 50 look nearly identical for half the cost. For still images only, the [MQTT camera entities](MQTT#-images-screenshot--camera) are far cheaper.
 
 
 ## MQTT

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -32,7 +32,7 @@ FreeKiosk includes a built-in REST API server for integration with **Home Assist
 |---|---|
 | **Default Port** | 8080 |
 | **Protocol** | HTTP (HTTPS planned) |
-| **Authentication** | Optional API Key (X-Api-Key header) |
+| **Authentication** | Optional API Key (`X-Api-Key` header, or HTTP Basic password) |
 | **Format** | JSON responses |
 
 
@@ -388,6 +388,62 @@ GET /api/camera/photo?camera=front&quality=60
 - Camera permission must be granted (already included in app permissions)
 - Photo resolution is automatically optimized (~1.2MP) for fast HTTP transfer
 - Higher quality values produce larger files
+
+#### `GET /api/camera/stream`
+
+Live **MJPEG** stream of the device camera, so a kiosk tablet can be used as a camera in Home Assistant.
+
+**Opt-in**: enable **Live Camera Stream** in Settings → Advanced → REST API. Until then the endpoint answers `503`.
+
+**Response**: `multipart/x-mixed-replace; boundary=frame` — an endless sequence of JPEG parts, one per frame. The response only ends when the client disconnects.
+
+**Query Parameters:** *(each overrides the configured default for that request)*
+
+
+| Parameter | Default | Description |
+|---|---|---|
+| **camera** | *(setting)* | Camera to use: `front` or `back` |
+| **fps** | *(setting, 10)* | Frames per second, 1-30 |
+| **quality** | *(setting, 60)* | JPEG compression quality, 1-100 |
+| **width** | *(setting, 1280)* | Largest camera resolution to use, 160-3840 |
+| **rotate** | *(setting, auto)* | Clockwise rotation in degrees: `0`, `90`, `180`, `270`. Derived from the sensor when unset |
+
+
+
+**Examples:**
+
+
+```bash
+# Watch with ffplay
+ffplay "http://TABLET_IP:8080/api/camera/stream?camera=front&fps=10"
+
+# In a web page
+<img src="http://TABLET_IP:8080/api/camera/stream" />
+
+# Save 10 seconds of stream
+curl -m 10 "http://TABLET_IP:8080/api/camera/stream?fps=5" -o stream.mjpeg
+```
+
+
+
+**Home Assistant** — the *MJPEG IP Camera* integration (Settings → Devices & Services → Add integration):
+
+
+| Field | Value |
+|---|---|
+| **MJPEG URL** | `http://TABLET_IP:8080/api/camera/stream?camera=front&fps=10` |
+| **Still image URL** | `http://TABLET_IP:8080/api/camera/photo?camera=front` |
+| **Username** | anything (ignored) |
+| **Password** | your API key, if one is set |
+
+
+
+**Notes:**
+- **Motion detection keeps working.** A camera can only have one client, so while the stream runs, movement is measured on the stream's own frames and wakes the screen exactly as the regular detector would. No configuration needed.
+- The camera is opened when the first viewer connects and released when the last one leaves.
+- Up to **2 concurrent viewers**; further requests get `503`. A second viewer asking for the other camera is refused too — one camera at a time.
+- Measured on a Xiaomi tablet at 1280×960, quality 60, 10 fps: ~8 fps sustained, ~80 KB per frame (~5 Mbit/s), ~66% of one CPU core. Lower `fps` and `quality` for wall-mounted tablets.
+- If the picture comes out sideways, set `rotate` — see the camera orientation note under `/api/camera/photo`.
 
 #### `GET /api/camera/list`
 
@@ -836,6 +892,15 @@ If an API key is configured, include it in requests:
 ```bash
 curl -H "X-Api-Key: your-api-key" http://tablet-ip:8080/api/status
 ```
+
+The key is also accepted as the **password of an HTTP Basic credential** (the username is ignored). This exists for clients that cannot send custom headers — Home Assistant's *MJPEG IP Camera* integration among them:
+
+```bash
+curl -u "freekiosk:your-api-key" http://tablet-ip:8080/api/status
+```
+
+> [!TIP]
+> Prefer the header when you can. A Basic credential travels in every request and, over plain HTTP, is no more protected than the header — but it does keep the key out of URLs, browser history and server logs, unlike a query parameter.
 
 
 ## Home Assistant Integration

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -439,7 +439,9 @@ curl -m 10 "http://TABLET_IP:8080/api/camera/stream?fps=5" -o stream.mjpeg
 
 
 **Notes:**
-- **Motion detection keeps working.** A camera can only have one client, so while the stream runs, movement is measured on the stream's own frames and wakes the screen exactly as the regular detector would. No configuration needed.
+- **Motion detection keeps working.** A camera can only have one client, so while the stream runs, movement is measured on the stream's own frames and wakes the screen through the same path as the regular detector. Nothing to configure — the sensitivity you chose still applies.
+  - Measured on a Xiaomi tablet: frames are compared twice a second instead of once, a still scene sits at a 0.005-0.012 changed-pixel ratio against 0.026 for the regular detector, and movement reached 0.16-0.56. Detection to screen wake took 19 ms.
+  - The one thing it does not see: a **colour change at constant brightness**, since only the luma plane is compared. Movement, people and lighting changes are unaffected.
 - The camera is opened when the first viewer connects and released when the last one leaves.
 - Up to **2 concurrent viewers**; further requests get `503`. A second viewer asking for the other camera is refused too — one camera at a time.
 - Measured on a Xiaomi tablet at 1280×960, quality 60, 10 fps: ~8 fps sustained, ~80 KB per frame (~5 Mbit/s), ~66% of one CPU core. Lower `fps` and `quality` for wall-mounted tablets.

--- a/src/components/ApiSettingsSection.tsx
+++ b/src/components/ApiSettingsSection.tsx
@@ -12,6 +12,7 @@ import {
   Alert,
   Clipboard,
   ActivityIndicator,
+  PermissionsAndroid,
 } from 'react-native';
 import SettingsSection from './settings/SettingsSection';
 import SettingsSwitch from './settings/SettingsSwitch';
@@ -34,6 +35,13 @@ export const ApiSettingsSection: React.FC<ApiSettingsSectionProps> = ({
   const [serverRunning, setServerRunning] = useState(false);
   const [localIp, setLocalIp] = useState('0.0.0.0');
   const [isLoading, setIsLoading] = useState(false);
+  // Live MJPEG camera stream
+  const [streamEnabled, setStreamEnabled] = useState(false);
+  const [streamCamera, setStreamCamera] = useState<'front' | 'back'>('front');
+  const [streamFps, setStreamFps] = useState('10');
+  const [streamQuality, setStreamQuality] = useState('60');
+  const [streamWidth, setStreamWidth] = useState('1280');
+  const [streamRotate, setStreamRotate] = useState('-1');
 
   // Load settings on mount
   useEffect(() => {
@@ -57,17 +65,33 @@ export const ApiSettingsSection: React.FC<ApiSettingsSectionProps> = ({
   }, []);
 
   const loadSettings = async () => {
-    const [enabled, port, key, control] = await Promise.all([
+    const [
+      enabled, port, key, control,
+      camStreamEnabled, camStreamCamera, camStreamFps,
+      camStreamQuality, camStreamWidth, camStreamRotate,
+    ] = await Promise.all([
       StorageService.getRestApiEnabled(),
       StorageService.getRestApiPort(),
       StorageService.getRestApiKey(),
       StorageService.getRestApiAllowControl(),
+      StorageService.getCameraStreamEnabled(),
+      StorageService.getCameraStreamCamera(),
+      StorageService.getCameraStreamFps(),
+      StorageService.getCameraStreamQuality(),
+      StorageService.getCameraStreamWidth(),
+      StorageService.getCameraStreamRotate(),
     ]);
 
     setApiEnabled(enabled);
     setApiPort(port.toString());
     setApiKey(key);
     setAllowControl(control);
+    setStreamEnabled(camStreamEnabled);
+    setStreamCamera(camStreamCamera);
+    setStreamFps(camStreamFps.toString());
+    setStreamQuality(camStreamQuality.toString());
+    setStreamWidth(camStreamWidth.toString());
+    setStreamRotate(camStreamRotate.toString());
 
     // Always sync server state with stored settings.
     // If the server is already running (started by KioskScreen) but with a stale config
@@ -171,6 +195,93 @@ export const ApiSettingsSection: React.FC<ApiSettingsSectionProps> = ({
     }
     
     onSettingsChanged?.();
+  };
+
+  /** Push the stored stream settings to the running server (no restart needed). */
+  const pushStreamSettings = async () => {
+    try {
+      await httpServer.updateCameraStreamSettings({
+        enabled: await StorageService.getCameraStreamEnabled(),
+        camera: await StorageService.getCameraStreamCamera(),
+        fps: await StorageService.getCameraStreamFps(),
+        quality: await StorageService.getCameraStreamQuality(),
+        width: await StorageService.getCameraStreamWidth(),
+        rotate: await StorageService.getCameraStreamRotate(),
+      });
+    } catch (error) {
+      console.log('[ApiSettings] Could not push camera stream settings:', error);
+    }
+  };
+
+  const handleStreamEnabledChange = async (value: boolean) => {
+    if (value) {
+      // The stream is served natively via Camera2 and needs the runtime permission
+      try {
+        const granted = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.CAMERA);
+        if (granted !== PermissionsAndroid.RESULTS.GRANTED) {
+          Alert.alert(
+            'Camera Permission Required',
+            'FreeKiosk needs camera access to serve a live stream.'
+          );
+          return;
+        }
+      } catch (error) {
+        console.error('[ApiSettings] Camera permission request failed:', error);
+        return;
+      }
+    }
+
+    setStreamEnabled(value);
+    await StorageService.saveCameraStreamEnabled(value);
+    await pushStreamSettings();
+    onSettingsChanged?.();
+  };
+
+  const handleStreamCameraChange = async (value: 'front' | 'back') => {
+    setStreamCamera(value);
+    await StorageService.saveCameraStreamCamera(value);
+    await pushStreamSettings();
+    onSettingsChanged?.();
+  };
+
+  const handleStreamFpsChange = async (value: string) => {
+    setStreamFps(value);
+    const fps = parseInt(value, 10);
+    if (!isNaN(fps) && fps >= 1 && fps <= 30) {
+      await StorageService.saveCameraStreamFps(fps);
+      await pushStreamSettings();
+      onSettingsChanged?.();
+    }
+  };
+
+  const handleStreamQualityChange = async (value: string) => {
+    setStreamQuality(value);
+    const quality = parseInt(value, 10);
+    if (!isNaN(quality) && quality >= 1 && quality <= 100) {
+      await StorageService.saveCameraStreamQuality(quality);
+      await pushStreamSettings();
+      onSettingsChanged?.();
+    }
+  };
+
+  const handleStreamWidthChange = async (value: string) => {
+    setStreamWidth(value);
+    const width = parseInt(value, 10);
+    if (!isNaN(width) && width >= 160 && width <= 3840) {
+      await StorageService.saveCameraStreamWidth(width);
+      await pushStreamSettings();
+      onSettingsChanged?.();
+    }
+  };
+
+  const handleStreamRotateChange = async (value: string) => {
+    setStreamRotate(value);
+    const rotate = parseInt(value, 10);
+    if (!isNaN(rotate) && [-1, 0, 90, 180, 270].includes(rotate)) {
+      await StorageService.saveCameraStreamRotate(rotate);
+      await pushStreamSettings();
+      onSettingsChanged?.();
+    }
   };
 
   const generateApiKey = () => {
@@ -282,6 +393,67 @@ export const ApiSettingsSection: React.FC<ApiSettingsSectionProps> = ({
             hint="Enable POST commands (brightness, reload, etc.)"
           />
 
+          {/* Live camera stream */}
+          <SettingsSwitch
+            label="Live Camera Stream"
+            value={streamEnabled}
+            onValueChange={handleStreamEnabledChange}
+            icon="video"
+            hint="Serve GET /api/camera/stream as MJPEG, for the MJPEG IP Camera integration in Home Assistant. While it runs, motion detection uses the stream frames instead of opening the camera itself."
+          />
+
+          {streamEnabled && (
+            <>
+              <SettingsSwitch
+                label="Use Back Camera"
+                value={streamCamera === 'back'}
+                onValueChange={(value) => handleStreamCameraChange(value ? 'back' : 'front')}
+                icon="camera-flip"
+                hint="Default camera for the stream. Overridable per request with ?camera=front|back."
+              />
+
+              <SettingsInput
+                label="Frames per Second"
+                value={streamFps}
+                onChangeText={handleStreamFpsChange}
+                placeholder="10"
+                keyboardType="numeric"
+                icon="speedometer"
+                hint="1-30. Higher values cost CPU and bandwidth; 5-10 is plenty for monitoring."
+              />
+
+              <SettingsInput
+                label="Stream JPEG Quality"
+                value={streamQuality}
+                onChangeText={handleStreamQualityChange}
+                placeholder="60"
+                keyboardType="numeric"
+                icon="quality-high"
+                hint="1-100. Lower values reduce bandwidth."
+              />
+
+              <SettingsInput
+                label="Stream Max Width (px)"
+                value={streamWidth}
+                onChangeText={handleStreamWidthChange}
+                placeholder="1280"
+                keyboardType="numeric"
+                icon="arrow-expand-horizontal"
+                hint="Largest camera resolution to use, 160-3840."
+              />
+
+              <SettingsInput
+                label="Stream Rotation"
+                value={streamRotate}
+                onChangeText={handleStreamRotateChange}
+                placeholder="-1"
+                keyboardType="numeric"
+                icon="rotate-right"
+                hint="-1 derives it from the sensor. Use 0, 90, 180 or 270 if the picture comes out sideways."
+              />
+            </>
+          )}
+
           {/* API Endpoints Info */}
           <View style={styles.endpointsContainer}>
             <Text style={styles.endpointsTitle}>Available Endpoints:</Text>
@@ -299,6 +471,10 @@ export const ApiSettingsSection: React.FC<ApiSettingsSectionProps> = ({
               <Text style={styles.endpoint}>/api/memory - RAM info</Text>
               <Text style={styles.endpoint}>/api/wifi - WiFi status</Text>
               <Text style={styles.endpoint}>/api/screenshot - Capture screen (PNG)</Text>
+              <Text style={styles.endpoint}>/api/camera/photo - Take a photo (JPEG)</Text>
+              {streamEnabled && (
+                <Text style={styles.endpoint}>/api/camera/stream - Live MJPEG stream</Text>
+              )}
             </View>
 
             {allowControl && (

--- a/src/components/ApiSettingsSection.tsx
+++ b/src/components/ApiSettingsSection.tsx
@@ -399,7 +399,7 @@ export const ApiSettingsSection: React.FC<ApiSettingsSectionProps> = ({
             value={streamEnabled}
             onValueChange={handleStreamEnabledChange}
             icon="video"
-            hint="Serve GET /api/camera/stream as MJPEG, for the MJPEG IP Camera integration in Home Assistant. A camera accepts a single client, so while someone is watching, motion detection switches to the stream's own frames: same sensitivity setting, checked twice as often, but colour changes at constant brightness are no longer detected."
+            hint="Serve GET /api/camera/stream as MJPEG, for the MJPEG IP Camera integration in Home Assistant. A camera only accepts one client at a time: while someone is watching the stream, motion detection works from its frames instead. It keeps your sensitivity setting, but does not behave exactly like the usual detection."
           />
 
           {streamEnabled && (

--- a/src/components/ApiSettingsSection.tsx
+++ b/src/components/ApiSettingsSection.tsx
@@ -399,7 +399,7 @@ export const ApiSettingsSection: React.FC<ApiSettingsSectionProps> = ({
             value={streamEnabled}
             onValueChange={handleStreamEnabledChange}
             icon="video"
-            hint="Serve GET /api/camera/stream as MJPEG, for the MJPEG IP Camera integration in Home Assistant. While it runs, motion detection uses the stream frames instead of opening the camera itself."
+            hint="Serve GET /api/camera/stream as MJPEG, for the MJPEG IP Camera integration in Home Assistant. A camera accepts a single client, so while someone is watching, motion detection switches to the stream's own frames: same sensitivity setting, checked twice as often, but colour changes at constant brightness are no longer detected."
           />
 
           {streamEnabled && (

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -128,6 +128,11 @@ export type IconName =
   // Features
   | 'camera'
   | 'camera-outline'
+  | 'camera-flip'
+  | 'video'
+  | 'rotate-right'
+  | 'quality-high'
+  | 'arrow-expand-horizontal'
   | 'motion-sensor'
   | 'keyboard'
   | 'keyboard-outline'

--- a/src/screens/KioskScreen.tsx
+++ b/src/screens/KioskScreen.tsx
@@ -689,10 +689,7 @@ const KioskScreen: React.FC<KioskScreenProps> = ({ navigation }) => {
         onCameraStreamMotion: () => {
           // Same wake path as the regular detector: while a stream holds the camera, movement
           // is measured on its frames instead.
-          if (!streamMotionAllowedRef.current) {
-            console.log('[API] Stream motion ignored — motion wake is not active right now');
-            return;
-          }
+          if (!streamMotionAllowedRef.current) return;
           console.log('[API] Motion detected in camera stream');
           onMotionDetectedRef.current?.();
         },
@@ -2423,11 +2420,6 @@ const KioskScreen: React.FC<KioskScreenProps> = ({ navigation }) => {
   useEffect(() => {
     streamMotionAllowedRef.current =
       motionAlwaysOn || (motionEnabled && (isPreCheckingMotion || isScreensaverActive));
-    console.log(
-      `[Motion] stream wake allowed=${streamMotionAllowedRef.current} ` +
-        `(alwaysOn=${motionAlwaysOn}, enabled=${motionEnabled}, ` +
-        `preCheck=${isPreCheckingMotion}, screensaver=${isScreensaverActive})`
-    );
   }, [motionAlwaysOn, motionEnabled, isPreCheckingMotion, isScreensaverActive]);
 
   const enableScreensaverEffects = async () => {

--- a/src/screens/KioskScreen.tsx
+++ b/src/screens/KioskScreen.tsx
@@ -59,6 +59,8 @@ const KioskScreen: React.FC<KioskScreenProps> = ({ navigation }) => {
   const [inactivityDelay, setInactivityDelay] = useState(600000);
   const [motionEnabled, setMotionEnabled] = useState(false);
   const [motionAlwaysOn, setMotionAlwaysOn] = useState(false);
+  // A live MJPEG stream holds the camera: motion detection must stand down while it runs
+  const [cameraStreamActive, setCameraStreamActive] = useState(false);
   const [motionCameraPosition, setMotionCameraPosition] = useState<'front' | 'back'>('front');
   const [motionSensitivity, setMotionSensitivity] = useState<'low' | 'medium' | 'high'>('medium');
   const [isPreCheckingMotion, setIsPreCheckingMotion] = useState(false); // Pre-check phase: motion is being monitored before activating the screensaver
@@ -672,6 +674,11 @@ const KioskScreen: React.FC<KioskScreenProps> = ({ navigation }) => {
           } catch (error) {
             console.error('[API] Error disabling auto-brightness:', error);
           }
+        },
+        onCameraStreamStateChanged: (streaming: boolean) => {
+          // Releases the camera for the stream, and picks detection back up afterwards
+          console.log('[API] Camera stream active:', streaming);
+          setCameraStreamActive(streaming);
         },
         onSetMotionAlwaysOn: async (value: boolean) => {
           try {
@@ -2664,7 +2671,7 @@ const KioskScreen: React.FC<KioskScreenProps> = ({ navigation }) => {
 
       {/* Motion Detector - Active during pre-check OR when screensaver is ON (only if screen is focused) */}
       <MotionDetector
-        enabled={isFocused && (motionAlwaysOn || (motionEnabled && (isPreCheckingMotion || isScreensaverActive)))}
+        enabled={isFocused && !cameraStreamActive && (motionAlwaysOn || (motionEnabled && (isPreCheckingMotion || isScreensaverActive)))}
         onMotionDetected={onMotionDetected}
         sensitivity={motionSensitivity}
         cameraPosition={motionCameraPosition}

--- a/src/screens/KioskScreen.tsx
+++ b/src/screens/KioskScreen.tsx
@@ -689,7 +689,10 @@ const KioskScreen: React.FC<KioskScreenProps> = ({ navigation }) => {
         onCameraStreamMotion: () => {
           // Same wake path as the regular detector: while a stream holds the camera, movement
           // is measured on its frames instead.
-          if (!streamMotionAllowedRef.current) return;
+          if (!streamMotionAllowedRef.current) {
+            console.log('[API] Stream motion ignored — motion wake is not active right now');
+            return;
+          }
           console.log('[API] Motion detected in camera stream');
           onMotionDetectedRef.current?.();
         },
@@ -2420,6 +2423,11 @@ const KioskScreen: React.FC<KioskScreenProps> = ({ navigation }) => {
   useEffect(() => {
     streamMotionAllowedRef.current =
       motionAlwaysOn || (motionEnabled && (isPreCheckingMotion || isScreensaverActive));
+    console.log(
+      `[Motion] stream wake allowed=${streamMotionAllowedRef.current} ` +
+        `(alwaysOn=${motionAlwaysOn}, enabled=${motionEnabled}, ` +
+        `preCheck=${isPreCheckingMotion}, screensaver=${isScreensaverActive})`
+    );
   }, [motionAlwaysOn, motionEnabled, isPreCheckingMotion, isScreensaverActive]);
 
   const enableScreensaverEffects = async () => {

--- a/src/screens/KioskScreen.tsx
+++ b/src/screens/KioskScreen.tsx
@@ -61,6 +61,12 @@ const KioskScreen: React.FC<KioskScreenProps> = ({ navigation }) => {
   const [motionAlwaysOn, setMotionAlwaysOn] = useState(false);
   // A live MJPEG stream holds the camera: motion detection must stand down while it runs
   const [cameraStreamActive, setCameraStreamActive] = useState(false);
+  // onMotionDetected is defined further down; the API callbacks are registered on mount and
+  // would otherwise capture a stale closure.
+  const onMotionDetectedRef = useRef<(() => void) | null>(null);
+  // Mirrors MotionDetector's own enabled condition, so movement coming from the camera stream
+  // wakes the screen in exactly the same situations.
+  const streamMotionAllowedRef = useRef(false);
   const [motionCameraPosition, setMotionCameraPosition] = useState<'front' | 'back'>('front');
   const [motionSensitivity, setMotionSensitivity] = useState<'low' | 'medium' | 'high'>('medium');
   const [isPreCheckingMotion, setIsPreCheckingMotion] = useState(false); // Pre-check phase: motion is being monitored before activating the screensaver
@@ -680,6 +686,13 @@ const KioskScreen: React.FC<KioskScreenProps> = ({ navigation }) => {
           console.log('[API] Camera stream active:', streaming);
           setCameraStreamActive(streaming);
         },
+        onCameraStreamMotion: () => {
+          // Same wake path as the regular detector: while a stream holds the camera, movement
+          // is measured on its frames instead.
+          if (!streamMotionAllowedRef.current) return;
+          console.log('[API] Motion detected in camera stream');
+          onMotionDetectedRef.current?.();
+        },
         onSetMotionAlwaysOn: async (value: boolean) => {
           try {
             setMotionAlwaysOn(value);
@@ -869,8 +882,10 @@ const KioskScreen: React.FC<KioskScreenProps> = ({ navigation }) => {
       autoBrightnessMin: autoBrightnessMin,
       autoBrightnessMax: autoBrightnessMax,
       motionAlwaysOn: motionAlwaysOn,
+      // Used by the stream-based motion detection, which takes over while a stream runs
+      motionSensitivity: motionSensitivity,
     });
-  }, [url, defaultBrightness, isScreensaverActive, urlRotationEnabled, urlRotationList, urlRotationInterval, currentUrlIndex, autoBrightnessEnabled, autoBrightnessMin, autoBrightnessMax, motionAlwaysOn]);
+  }, [url, defaultBrightness, isScreensaverActive, urlRotationEnabled, urlRotationList, urlRotationInterval, currentUrlIndex, autoBrightnessEnabled, autoBrightnessMin, autoBrightnessMax, motionAlwaysOn, motionSensitivity]);
 
   // Countdown timer effect (transparent - no UI)
   useEffect(() => {
@@ -2393,6 +2408,19 @@ const KioskScreen: React.FC<KioskScreenProps> = ({ navigation }) => {
       resetTimer();
     }
   }, [defaultBrightness, resetTimer, autoBrightnessEnabled]);
+
+  // Expose the current handler to the API callbacks registered on mount, so motion coming from
+  // the camera stream wakes the screen exactly like the regular detector does.
+  useEffect(() => {
+    onMotionDetectedRef.current = onMotionDetected;
+  }, [onMotionDetected]);
+
+  // Same condition as the MotionDetector `enabled` prop below, minus the stream check: while a
+  // stream runs, its frames are the motion source instead of the detector.
+  useEffect(() => {
+    streamMotionAllowedRef.current =
+      motionAlwaysOn || (motionEnabled && (isPreCheckingMotion || isScreensaverActive));
+  }, [motionAlwaysOn, motionEnabled, isPreCheckingMotion, isScreensaverActive]);
 
   const enableScreensaverEffects = async () => {
     // Content modes (URL/video) keep the current brightness so the user can see the content

--- a/src/utils/ApiService.ts
+++ b/src/utils/ApiService.ts
@@ -93,12 +93,14 @@ class ApiServiceClass {
    * Initialize the API service and start listening for commands
    */
   async initialize(callbacks: ApiCallbacks): Promise<void> {
+    // Always adopt the latest callbacks: KioskScreen remounts (settings reload, navigation)
+    // and the previous instance's closures capture state that is no longer updated.
+    this.callbacks = callbacks;
+
     if (this.isInitialized) {
-      console.log('ApiService: Already initialized');
+      console.log('ApiService: Callbacks refreshed');
       return;
     }
-
-    this.callbacks = callbacks;
 
     if (Platform.OS === 'android' && HttpServerModule) {
       this.eventEmitter = new NativeEventEmitter(HttpServerModule);

--- a/src/utils/ApiService.ts
+++ b/src/utils/ApiService.ts
@@ -118,6 +118,18 @@ class ApiServiceClass {
     }
 
     this.isInitialized = true;
+
+    // A stream may already be running (the kiosk screen remounts on settings reload, losing
+    // its state). Ask the native side for the truth so motion detection stays out of the way.
+    try {
+      const streaming = await httpServer.isCameraStreaming();
+      if (streaming) {
+        console.log('ApiService: A camera stream is already running');
+        this.callbacks.onCameraStreamStateChanged?.(true);
+      }
+    } catch (error) {
+      // Older native module without the method, or server not started yet
+    }
   }
 
   /**

--- a/src/utils/ApiService.ts
+++ b/src/utils/ApiService.ts
@@ -35,6 +35,11 @@ export interface ApiCallbacks {
   onAutoBrightnessDisable?: () => void;
   onSetMotionAlwaysOn?: (value: boolean) => void;
   onSetMode?: (mode: 'webview' | 'external_app' | 'media_player', target?: string) => void;
+  /**
+   * A live camera stream started (true) or ended (false). Motion detection must release the
+   * camera while a stream is running: only one client can hold the sensor.
+   */
+  onCameraStreamStateChanged?: (streaming: boolean) => void;
 }
 
 export interface AppStatus {
@@ -62,6 +67,7 @@ class ApiServiceClass {
   private callbacks: ApiCallbacks = {};
   private eventEmitter: NativeEventEmitter | null = null;
   private commandSubscription: any = null;
+  private cameraStreamSubscription: any = null;
   private appStatus: AppStatus = {
     currentUrl: '',
     canGoBack: false,
@@ -96,6 +102,15 @@ class ApiServiceClass {
         'onApiCommand',
         (event: { command: string; params: string }) => {
           setTimeout(() => this.handleCommand(event), 0);
+        }
+      );
+
+      // Camera arbitration: the native stream manager tells us when it needs the camera
+      this.cameraStreamSubscription = this.eventEmitter.addListener(
+        'onCameraStreamState',
+        (event: { streaming: boolean }) => {
+          console.log('ApiService: Camera stream state', event.streaming);
+          this.callbacks.onCameraStreamStateChanged?.(event.streaming === true);
         }
       );
 
@@ -369,6 +384,10 @@ class ApiServiceClass {
     if (this.commandSubscription) {
       this.commandSubscription.remove();
       this.commandSubscription = null;
+    }
+    if (this.cameraStreamSubscription) {
+      this.cameraStreamSubscription.remove();
+      this.cameraStreamSubscription = null;
     }
     this.isInitialized = false;
     console.log('ApiService: Destroyed');

--- a/src/utils/ApiService.ts
+++ b/src/utils/ApiService.ts
@@ -165,8 +165,29 @@ class ApiServiceClass {
 
       const result = await httpServer.startServer(port, apiKey || null, allowControl);
       console.log(`ApiService: Server started on ${result.ip}:${result.port}`);
+
+      await this.pushCameraStreamSettings();
     } catch (error) {
       console.error('ApiService: Failed to auto-start server', error);
+    }
+  }
+
+  /**
+   * Push the live camera stream settings to the running server. Called on start and whenever
+   * the settings change, so toggling the stream takes effect without restarting the server.
+   */
+  async pushCameraStreamSettings(): Promise<void> {
+    try {
+      await httpServer.updateCameraStreamSettings({
+        enabled: await StorageService.getCameraStreamEnabled(),
+        camera: await StorageService.getCameraStreamCamera(),
+        fps: await StorageService.getCameraStreamFps(),
+        quality: await StorageService.getCameraStreamQuality(),
+        width: await StorageService.getCameraStreamWidth(),
+        rotate: await StorageService.getCameraStreamRotate(),
+      });
+    } catch (error) {
+      console.log('ApiService: Could not push camera stream settings', error);
     }
   }
 

--- a/src/utils/ApiService.ts
+++ b/src/utils/ApiService.ts
@@ -40,6 +40,11 @@ export interface ApiCallbacks {
    * camera while a stream is running: only one client can hold the sensor.
    */
   onCameraStreamStateChanged?: (streaming: boolean) => void;
+  /**
+   * Movement seen in the live camera stream. While a stream runs it is the only motion source:
+   * the regular detector cannot open the same sensor.
+   */
+  onCameraStreamMotion?: () => void;
 }
 
 export interface AppStatus {
@@ -61,6 +66,8 @@ export interface AppStatus {
   scheduledSleep?: boolean;
   motionDetected?: boolean;
   motionAlwaysOn?: boolean;
+  /** Sensitivity used by the stream-based motion detection */
+  motionSensitivity?: 'low' | 'medium' | 'high';
 }
 
 class ApiServiceClass {
@@ -68,6 +75,7 @@ class ApiServiceClass {
   private eventEmitter: NativeEventEmitter | null = null;
   private commandSubscription: any = null;
   private cameraStreamSubscription: any = null;
+  private cameraStreamMotionSubscription: any = null;
   private appStatus: AppStatus = {
     currentUrl: '',
     canGoBack: false,
@@ -111,6 +119,14 @@ class ApiServiceClass {
         (event: { streaming: boolean }) => {
           console.log('ApiService: Camera stream state', event.streaming);
           this.callbacks.onCameraStreamStateChanged?.(event.streaming === true);
+        }
+      );
+
+      this.cameraStreamMotionSubscription = this.eventEmitter.addListener(
+        'onCameraStreamMotion',
+        () => {
+          console.log('ApiService: Motion detected in camera stream');
+          this.callbacks.onCameraStreamMotion?.();
         }
       );
 
@@ -400,6 +416,10 @@ class ApiServiceClass {
     if (this.cameraStreamSubscription) {
       this.cameraStreamSubscription.remove();
       this.cameraStreamSubscription = null;
+    }
+    if (this.cameraStreamMotionSubscription) {
+      this.cameraStreamMotionSubscription.remove();
+      this.cameraStreamMotionSubscription = null;
     }
     this.isInitialized = false;
     console.log('ApiService: Destroyed');

--- a/src/utils/BackupService.ts
+++ b/src/utils/BackupService.ts
@@ -55,6 +55,13 @@ const BACKUP_KEYS = [
   '@kiosk_rest_api_port',
   // Note: @kiosk_rest_api_key is handled separately via Keychain (secure storage)
   '@kiosk_rest_api_allow_control',
+  // Live MJPEG camera stream
+  '@kiosk_camera_stream_enabled',
+  '@kiosk_camera_stream_camera',
+  '@kiosk_camera_stream_fps',
+  '@kiosk_camera_stream_quality',
+  '@kiosk_camera_stream_width',
+  '@kiosk_camera_stream_rotate',
   '@kiosk_allow_power_button',
   '@kiosk_block_factory_reset',
   '@kiosk_allow_notifications',

--- a/src/utils/HttpServerModule.ts
+++ b/src/utils/HttpServerModule.ts
@@ -78,6 +78,27 @@ class HttpServerService {
   }
 
   /**
+   * Apply the live MJPEG stream settings. Streaming is refused until this is called with
+   * `enabled: true`; disabling it also drops any viewer currently connected.
+   *
+   * @param settings.rotate extra clockwise rotation in degrees, or -1 to derive it from the sensor
+   */
+  async updateCameraStreamSettings(settings: {
+    enabled: boolean;
+    camera: 'front' | 'back';
+    fps: number;
+    quality: number;
+    width: number;
+    rotate: number;
+  }): Promise<boolean> {
+    if (Platform.OS !== 'android' || !HttpServerModule?.updateCameraStreamSettings) {
+      return false;
+    }
+
+    return HttpServerModule.updateCameraStreamSettings(settings);
+  }
+
+  /**
    * Whether a live camera stream is currently running natively. Used to resynchronise the
    * JS state after a remount, so motion detection does not steal the camera from a stream.
    */

--- a/src/utils/HttpServerModule.ts
+++ b/src/utils/HttpServerModule.ts
@@ -78,6 +78,18 @@ class HttpServerService {
   }
 
   /**
+   * Whether a live camera stream is currently running natively. Used to resynchronise the
+   * JS state after a remount, so motion detection does not steal the camera from a stream.
+   */
+  async isCameraStreaming(): Promise<boolean> {
+    if (Platform.OS !== 'android' || !HttpServerModule?.isCameraStreaming) {
+      return false;
+    }
+
+    return HttpServerModule.isCameraStreaming();
+  }
+
+  /**
    * Get server info (running status and IP)
    */
   async getServerInfo(): Promise<ServerInfo> {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -61,6 +61,13 @@ const KEYS = {
   REST_API_PORT: '@kiosk_rest_api_port',
   REST_API_KEY: '@kiosk_rest_api_key',
   REST_API_ALLOW_CONTROL: '@kiosk_rest_api_allow_control',
+  // Live MJPEG camera stream (GET /api/camera/stream)
+  CAMERA_STREAM_ENABLED: '@kiosk_camera_stream_enabled',
+  CAMERA_STREAM_CAMERA: '@kiosk_camera_stream_camera',
+  CAMERA_STREAM_FPS: '@kiosk_camera_stream_fps',
+  CAMERA_STREAM_QUALITY: '@kiosk_camera_stream_quality',
+  CAMERA_STREAM_WIDTH: '@kiosk_camera_stream_width',
+  CAMERA_STREAM_ROTATE: '@kiosk_camera_stream_rotate',
   // Power Button setting
   ALLOW_POWER_BUTTON: '@kiosk_allow_power_button',
   // Block factory reset in system Settings (Device Owner user restriction) (#201)
@@ -1433,6 +1440,121 @@ export const StorageService = {
     } catch (error) {
       console.error('Error getting REST API allow control:', error);
       return true;
+    }
+  },
+
+  // LIVE CAMERA STREAM (MJPEG)
+  saveCameraStreamEnabled: async (value: boolean): Promise<void> => {
+    try {
+      await AsyncStorage.setItem(KEYS.CAMERA_STREAM_ENABLED, JSON.stringify(value));
+    } catch (error) {
+      console.error('Error saving camera stream enabled:', error);
+    }
+  },
+
+  getCameraStreamEnabled: async (): Promise<boolean> => {
+    try {
+      const value = await AsyncStorage.getItem(KEYS.CAMERA_STREAM_ENABLED);
+      return value ? JSON.parse(value) : false;
+    } catch (error) {
+      console.error('Error getting camera stream enabled:', error);
+      return false;
+    }
+  },
+
+  saveCameraStreamCamera: async (camera: 'front' | 'back'): Promise<void> => {
+    try {
+      await AsyncStorage.setItem(KEYS.CAMERA_STREAM_CAMERA, camera);
+    } catch (error) {
+      console.error('Error saving camera stream camera:', error);
+    }
+  },
+
+  getCameraStreamCamera: async (): Promise<'front' | 'back'> => {
+    try {
+      const value = await AsyncStorage.getItem(KEYS.CAMERA_STREAM_CAMERA);
+      return value === 'back' ? 'back' : 'front';
+    } catch (error) {
+      console.error('Error getting camera stream camera:', error);
+      return 'front';
+    }
+  },
+
+  saveCameraStreamFps: async (fps: number): Promise<void> => {
+    try {
+      await AsyncStorage.setItem(KEYS.CAMERA_STREAM_FPS, fps.toString());
+    } catch (error) {
+      console.error('Error saving camera stream fps:', error);
+    }
+  },
+
+  getCameraStreamFps: async (): Promise<number> => {
+    try {
+      const value = await AsyncStorage.getItem(KEYS.CAMERA_STREAM_FPS);
+      const fps = value ? parseInt(value, 10) : 10;
+      return isNaN(fps) ? 10 : Math.min(30, Math.max(1, fps));
+    } catch (error) {
+      console.error('Error getting camera stream fps:', error);
+      return 10;
+    }
+  },
+
+  saveCameraStreamQuality: async (quality: number): Promise<void> => {
+    try {
+      await AsyncStorage.setItem(KEYS.CAMERA_STREAM_QUALITY, quality.toString());
+    } catch (error) {
+      console.error('Error saving camera stream quality:', error);
+    }
+  },
+
+  getCameraStreamQuality: async (): Promise<number> => {
+    try {
+      const value = await AsyncStorage.getItem(KEYS.CAMERA_STREAM_QUALITY);
+      const quality = value ? parseInt(value, 10) : 60;
+      return isNaN(quality) ? 60 : Math.min(100, Math.max(1, quality));
+    } catch (error) {
+      console.error('Error getting camera stream quality:', error);
+      return 60;
+    }
+  },
+
+  saveCameraStreamWidth: async (width: number): Promise<void> => {
+    try {
+      await AsyncStorage.setItem(KEYS.CAMERA_STREAM_WIDTH, width.toString());
+    } catch (error) {
+      console.error('Error saving camera stream width:', error);
+    }
+  },
+
+  getCameraStreamWidth: async (): Promise<number> => {
+    try {
+      const value = await AsyncStorage.getItem(KEYS.CAMERA_STREAM_WIDTH);
+      const width = value ? parseInt(value, 10) : 1280;
+      return isNaN(width) ? 1280 : Math.min(3840, Math.max(160, width));
+    } catch (error) {
+      console.error('Error getting camera stream width:', error);
+      return 1280;
+    }
+  },
+
+  /** Extra clockwise rotation in degrees, or -1 to derive it from the sensor. */
+  saveCameraStreamRotate: async (rotate: number): Promise<void> => {
+    try {
+      await AsyncStorage.setItem(KEYS.CAMERA_STREAM_ROTATE, rotate.toString());
+    } catch (error) {
+      console.error('Error saving camera stream rotation:', error);
+    }
+  },
+
+  getCameraStreamRotate: async (): Promise<number> => {
+    try {
+      const value = await AsyncStorage.getItem(KEYS.CAMERA_STREAM_ROTATE);
+      const rotate = value ? parseInt(value, 10) : -1;
+      if (isNaN(rotate)) return -1;
+      return [0, 90, 180, 270].includes(rotate) ? rotate : -1;
+    } catch (error) {
+      console.error('Error getting camera stream rotation:', error);
+      return -1;
     }
   },
 


### PR DESCRIPTION
## 📝 Description

Adds `GET /api/camera/stream`, an endless `multipart/x-mixed-replace` response serving JPEG frames, so a kiosk tablet can be used as a live camera in Home Assistant through the *MJPEG IP Camera* integration. MQTT cannot carry this: its `image` / `camera` platforms take one picture per message.

**Opt-in**: a *Live Camera Stream* switch in Settings → Advanced → REST API, off by default. Until it is on, the endpoint answers `503`.

How it is built:

- **`Camera2MjpegSource`** runs a repeating preview request on a `YUV_420_888` `ImageReader` and compresses frames with `YuvImage`. A repeating JPEG request would re-run the full still-capture pipeline for every frame and is unreliable across devices. Frames are rotated in NV21, because MJPEG viewers ignore EXIF.
- **`CameraStreamManager`** opens the camera on the first viewer and releases it on the last, caps concurrent viewers at 2, and gives each one a small drop-oldest queue so a slow reader cannot stall the capture loop. If the sensor is taken away mid-stream, viewers are ended immediately instead of hanging until a timeout.
- **Motion detection keeps working.** A camera accepts a single client, so a permanent stream and the camera-based detector cannot coexist on one sensor. Since the pipeline already decodes every frame, movement is measured on the luma plane instead of opening a second camera client. The detector is suspended while a stream runs and resumes when the last viewer leaves. The user's sensitivity setting still applies.
- **Basic auth**: the API key is now also accepted as an HTTP Basic password (any username), because Home Assistant's MJPEG integration cannot send custom headers. This keeps the key out of URLs and logs, unlike a query parameter.

Refs #226

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement

## ✅ Testing

- [x] Tested on real Android device
- [ ] Tested in Device Owner mode — *not tested*
- [ ] Tested on multiple Android versions: **Android 16 only**
- [x] No regressions found

**Device(s) tested:**
- Device: Xiaomi 25097RP43G
- Android version: 16 (API 36, HyperOS OS3.0)

Measured at 1280×960, quality 60, 10 fps requested:

| Check | Result |
|---|---|
| Throughput | 8.2 fps sustained, ~81 KB per frame (~5.3 Mbit/s) |
| CPU | ~66% of one core |
| Temperature | stable over the test runs |
| Frames | valid JPEGs, correct orientation |
| Two viewers | both served at full rate |
| Third viewer | refused with a clear JSON error |
| Camera lifecycle | opened on the first viewer, released on the last |
| Disabled by setting | endpoint answers `503`, viewers dropped when turned off |
| Settings changes | applied without restarting the server |

Motion detection from the stream frames, same device:

| Check | Result |
|---|---|
| Still scene | 0.005–0.012 changed-pixel ratio |
| Person moving | 0.16–0.56 |
| Regular detector, still scene *(for comparison)* | 0.026 |
| Wake path | motion at 13:51:35.712 → JS event at .715 → screen awake at .731 (**19 ms**), stream still holding the camera |

Not covered by this round:

- Devices whose camera stack refuses two sensors at once, and devices where CameraX/vision-camera already needs the Camera2 fallback.
- The `rotate` override: only the automatic value was exercised (it came out correct on this tablet).
- Long-run behaviour: the longest continuous stream in testing was a few minutes, not hours.
- `npm test` is not a signal here: the suite fails on `main` as well (`__tests__/App.test.tsx` cannot be transformed, `@react-navigation` ESM).

## 📸 Screenshots/Videos

<img width="2136" height="1632" alt="image-1785586798322" src="https://github.com/user-attachments/assets/bd464f52-8a95-4faf-8091-684e413d6f2e" />

## 📋 Checklist

- [x] My code follows the project's code style
- [x] I have commented my code where necessary
- [x] I have updated the documentation accordingly (`docs/rest-api.md`, `docs/INTEGRATIONS.md`)
- [x] My changes generate no new warnings (`npm run typecheck` clean, `eslint` counts unchanged on touched files, Kotlin compiles with no new warnings)
- [x] I have tested on a real device (not just emulator)
- [ ] All existing tests still pass — see the note above, the suite is already failing on `main`

## 🔗 Related Issues/PRs

- Refs #226
- Builds on the same camera code as #182 but does not depend on it: this branch starts from `main` so the two can be reviewed independently.

## 📝 Additional Notes

**One commit here is broader than this feature and you may want it separately.** `4f1868e` fixes `ApiService.initialize()`, which returned early once initialized and therefore kept the callbacks registered by the first `KioskScreen` instance. That instance is replaced on every settings reload, and its state stops being updated — so after a remount, **every** REST and MQTT command ran against stale values, not just this feature. I found it because a motion event reached JS and was dropped by a screensaver flag belonging to a dead component. Happy to pull it out into its own PR if you would rather merge it quickly and independently.

Two smaller things noticed while working here, not addressed:

- `android/gradle.properties.template` sets `newArchEnabled=false`, but `react-native-brightness-newarch` only registers under the New Architecture: a build following the template crashes at startup with `RNBrightnessNewArch could not be found`. I built with `-PnewArchEnabled=true` throughout.
- Camera photos are served without a JPEG orientation, which is a pre-existing issue of `/api/camera/photo`; the stream rotates frames itself so it is unaffected.