### PR TITLE
feat: cellular in the status bar and the heartbeat, and block airplane mode

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -55,6 +55,9 @@
 
     <!-- Permissions pour la Status Bar -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+  <!-- Cellular generation (5G/4G) and signal strength for the status bar and the
+       cloud dashboard. Stripped from Play Store builds by src/playstore. -->
+  <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />

--- a/android/app/src/main/java/com/freekiosk/KioskModule.kt
+++ b/android/app/src/main/java/com/freekiosk/KioskModule.kt
@@ -578,6 +578,50 @@ class KioskModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaM
         }
     }
 
+    /**
+     * Block (or unblock) airplane mode via a Device Owner user restriction (#130).
+     *
+     * A beta tester had a tablet hang on startup after someone enabled airplane mode:
+     * the kiosk sat on a URL it could not load. He asked for airplane mode to be turned
+     * off at boot, and DISALLOW_AIRPLANE_MODE is better than that, because it stops the
+     * user reaching the toggle at all rather than undoing the damage one reboot later.
+     * Persistent across reboots, like DISALLOW_FACTORY_RESET above.
+     *
+     * Device Owner only, and there is no fallback: switching airplane mode from a
+     * third-party app has been closed off since Android 4.2, the broadcast is the
+     * system's. No-op (resolves false) when not Device Owner or below API 28.
+     */
+    @ReactMethod
+    fun setAirplaneModeBlocked(blocked: Boolean, promise: Promise) {
+        try {
+            if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.P) {
+                android.util.Log.d("KioskModule", "setAirplaneModeBlocked: needs API 28, no-op")
+                promise.resolve(false)
+                return
+            }
+
+            val dpm = reactApplicationContext.getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager
+            val adminComponent = ComponentName(reactApplicationContext, DeviceAdminReceiver::class.java)
+
+            if (!dpm.isDeviceOwnerApp(reactApplicationContext.packageName)) {
+                android.util.Log.d("KioskModule", "setAirplaneModeBlocked: not Device Owner, no-op")
+                promise.resolve(false)
+                return
+            }
+
+            if (blocked) {
+                dpm.addUserRestriction(adminComponent, android.os.UserManager.DISALLOW_AIRPLANE_MODE)
+            } else {
+                dpm.clearUserRestriction(adminComponent, android.os.UserManager.DISALLOW_AIRPLANE_MODE)
+            }
+            android.util.Log.d("KioskModule", "Airplane mode restriction ${if (blocked) "applied" else "cleared"}")
+            promise.resolve(true)
+        } catch (e: Exception) {
+            android.util.Log.e("KioskModule", "setAirplaneModeBlocked error: ${e.message}")
+            promise.resolve(false)
+        }
+    }
+
     @ReactMethod
     fun startLockTask(externalAppPackage: String?, allowPowerButton: Boolean, allowNotifications: Boolean, allowSystemInfo: Boolean, allowEmergencyCall: Boolean, promise: Promise) {
         try {

--- a/android/app/src/main/java/com/freekiosk/SystemInfoModule.kt
+++ b/android/app/src/main/java/com/freekiosk/SystemInfoModule.kt
@@ -7,6 +7,8 @@ import android.os.BatteryManager
 import android.Manifest
 import android.content.pm.PackageManager
 import android.location.LocationManager
+import android.provider.Settings
+import android.telephony.TelephonyManager
 import android.net.wifi.WifiInfo
 import android.net.wifi.WifiManager
 import android.net.ConnectivityManager
@@ -41,6 +43,10 @@ class SystemInfoModule(reactContext: ReactApplicationContext) : ReactContextBase
             // WiFi info
             val wifiInfo = getWiFiInfo()
             systemInfo.putMap("wifi", wifiInfo)
+
+            // Cellular info, reported alongside WiFi so the dashboard can show both
+            val cellularInfo = getCellularInfo()
+            systemInfo.putMap("cellular", cellularInfo)
 
             // Bluetooth info
             val bluetoothInfo = getBluetoothInfo()
@@ -102,6 +108,127 @@ class SystemInfoModule(reactContext: ReactApplicationContext) : ReactContextBase
         }
 
         return batteryInfo
+    }
+
+    /**
+     * Cellular state, shaped like getWiFiInfo so the two read the same in the payload.
+     *
+     * Three of the four values cost nothing: TRANSPORT_CELLULAR, the SIM operator name
+     * and airplane mode are all readable with no permission. The network generation and
+     * the signal in dBm need READ_PHONE_STATE, which is declared in the main manifest
+     * and stripped from Play Store builds by the src/playstore overlay, so both are
+     * guarded rather than assumed: without the permission they come back empty and the
+     * rest still reports.
+     *
+     * Requested by a beta tester running tablets on mobile data, who had a device hang
+     * on startup after someone enabled airplane mode with nothing on screen to say so.
+     */
+    /**
+     * Cellular only, so the 30-second heartbeat does not pay for battery, WiFi,
+     * bluetooth and audio just to read one section.
+     */
+    @ReactMethod
+    fun getCellularInfo(promise: Promise) {
+        try {
+            promise.resolve(getCellularInfo())
+        } catch (e: Exception) {
+            promise.reject("CELLULAR_INFO_ERROR", e.message, e)
+        }
+    }
+
+    private fun getCellularInfo(): WritableMap {
+        val cellularInfo = Arguments.createMap()
+
+        try {
+            val connectivityManager = reactApplicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+            val network = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) connectivityManager.activeNetwork else null
+            val capabilities = if (network != null) connectivityManager.getNetworkCapabilities(network) else null
+
+            val isConnected = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) == true
+            } else {
+                @Suppress("DEPRECATION")
+                connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_MOBILE)?.isConnected == true
+            }
+            cellularInfo.putBoolean("isConnected", isConnected)
+
+            val telephonyManager = reactApplicationContext.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
+            cellularInfo.putString("carrier", telephonyManager.simOperatorName ?: "")
+
+            cellularInfo.putString("networkType", getCellularGeneration(telephonyManager))
+            val dbm = getCellularSignalDbm(telephonyManager)
+            if (dbm != null) cellularInfo.putInt("signalDbm", dbm) else cellularInfo.putNull("signalDbm")
+
+            cellularInfo.putBoolean("airplaneMode", isAirplaneModeOn())
+        } catch (e: Exception) {
+            DebugLog.errorProduction("SystemInfo", "Cellular error: ${e.message}")
+            cellularInfo.putBoolean("isConnected", false)
+            cellularInfo.putString("carrier", "")
+            cellularInfo.putString("networkType", "")
+            cellularInfo.putNull("signalDbm")
+            cellularInfo.putBoolean("airplaneMode", false)
+        }
+
+        return cellularInfo
+    }
+
+    /** Whether READ_PHONE_STATE is actually held; a Play Store build never has it. */
+    private fun hasPhoneStatePermission(): Boolean =
+        reactApplicationContext.checkSelfPermission(Manifest.permission.READ_PHONE_STATE) ==
+            PackageManager.PERMISSION_GRANTED
+
+    /**
+     * "5G", "4G", "3G", "2G", or "" when unknown or unreadable.
+     *
+     * Note a known limit rather than hiding it: on a 5G non-standalone network the data
+     * network type reads LTE while the device is in fact on 5G, because the anchor is
+     * LTE. Reading through ServiceState to catch that needs more privilege than this is
+     * worth, so a NSA device reports 4G.
+     */
+    private fun getCellularGeneration(telephonyManager: TelephonyManager): String {
+        if (!hasPhoneStatePermission()) return ""
+        return try {
+            val type = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                telephonyManager.dataNetworkType
+            } else {
+                @Suppress("DEPRECATION")
+                telephonyManager.networkType
+            }
+            when (type) {
+                TelephonyManager.NETWORK_TYPE_NR -> "5G"
+                TelephonyManager.NETWORK_TYPE_LTE, TelephonyManager.NETWORK_TYPE_IWLAN -> "4G"
+                TelephonyManager.NETWORK_TYPE_HSPAP, TelephonyManager.NETWORK_TYPE_HSPA,
+                TelephonyManager.NETWORK_TYPE_HSDPA, TelephonyManager.NETWORK_TYPE_HSUPA,
+                TelephonyManager.NETWORK_TYPE_UMTS, TelephonyManager.NETWORK_TYPE_EVDO_A,
+                TelephonyManager.NETWORK_TYPE_EVDO_B, TelephonyManager.NETWORK_TYPE_EHRPD -> "3G"
+                TelephonyManager.NETWORK_TYPE_EDGE, TelephonyManager.NETWORK_TYPE_GPRS,
+                TelephonyManager.NETWORK_TYPE_CDMA, TelephonyManager.NETWORK_TYPE_1xRTT,
+                TelephonyManager.NETWORK_TYPE_GSM -> "2G"
+                else -> ""
+            }
+        } catch (e: SecurityException) {
+            ""
+        }
+    }
+
+    /** Signal in dBm, or null without READ_PHONE_STATE or on Android below 10. */
+    private fun getCellularSignalDbm(telephonyManager: TelephonyManager): Int? {
+        if (!hasPhoneStatePermission()) return null
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return null
+        return try {
+            telephonyManager.signalStrength?.cellSignalStrengths?.firstOrNull()?.dbm
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /** Airplane mode. Readable with no permission, and the point of the request. */
+    private fun isAirplaneModeOn(): Boolean = try {
+        Settings.Global.getInt(
+            reactApplicationContext.contentResolver, Settings.Global.AIRPLANE_MODE_ON, 0
+        ) == 1
+    } catch (e: Exception) {
+        false
     }
 
     private fun getWiFiInfo(): WritableMap {

--- a/android/app/src/playstore/AndroidManifest.xml
+++ b/android/app/src/playstore/AndroidManifest.xml
@@ -18,6 +18,14 @@
         android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"
         tools:node="remove" />
 
+    <!-- Strip READ_PHONE_STATE: the cellular generation and signal are a convenience,
+         and a phone-state permission on a kiosk browser is exactly the kind of thing
+         that costs a Play Store review. Cellular connected/disconnected and airplane
+         mode need no permission, so a Play build keeps those. -->
+    <uses-permission
+        android:name="android.permission.READ_PHONE_STATE"
+        tools:node="remove" />
+
     <!-- Strip WRITE_SETTINGS (Device settings policy) -->
     <uses-permission
         android:name="android.permission.WRITE_SETTINGS"

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -12,6 +12,13 @@ interface SystemInfo {
   wifi: {
     isConnected: boolean;
   };
+  cellular?: {
+    isConnected: boolean;
+    carrier: string;
+    networkType: string;
+    signalDbm: number | null;
+    airplaneMode: boolean;
+  };
   bluetooth: {
     isEnabled: boolean;
     connectedDevices: number;
@@ -113,6 +120,15 @@ const StatusBar: React.FC<StatusBarProps> = ({
   const batteryLevel = systemInfo?.battery?.level ?? 0;
   const isCharging = systemInfo?.battery?.isCharging ?? false;
   const wifiConnected = systemInfo?.wifi?.isConnected ?? false;
+  const cellularConnected = systemInfo?.cellular?.isConnected ?? false;
+  const airplaneMode = systemInfo?.cellular?.airplaneMode ?? false;
+  // networkType is '' on any build without READ_PHONE_STATE (every Play Store build),
+  // so the icon falls back to a plain signal bar rather than showing nothing.
+  const cellularType = systemInfo?.cellular?.networkType ?? '';
+  // No dedicated toggle: the item appears only on a device that actually has cellular
+  // in play, so a WiFi-only kiosk is unchanged and no new setting had to cross the app
+  // and the cloud to ship this.
+  const cellularPresent = cellularConnected || airplaneMode;
   const bluetoothEnabled = systemInfo?.bluetooth?.isEnabled ?? false;
   const bluetoothDevices = systemInfo?.bluetooth?.connectedDevices ?? 0;
   const audioVolume = systemInfo?.audio?.volume ?? 0;
@@ -181,6 +197,33 @@ const StatusBar: React.FC<StatusBarProps> = ({
           style={styles.iconMaterial}
         />
         <Text style={[styles.text, { color: colors.text }]}>{batteryLevel}%</Text>
+      </View>
+    );
+  }
+
+  // Cellular - left side, next to WiFi
+  //
+  // Airplane mode wins the display when it is on: it is the state that made a tester's
+  // tablet hang on startup with nothing anywhere saying why, so it is worth more than
+  // the generation on screen.
+  if (cellularPresent) {
+    leftItems.push(
+      <View key="cellular" style={styles.item}>
+        <MaterialCommunityIcons
+          name={airplaneMode ? 'airplane' : 'signal'}
+          size={14}
+          color={airplaneMode ? colors.disconnected : colors.icon}
+          style={styles.iconMaterial}
+        />
+        {cellularType ? (
+          <Text style={[styles.text, { color: colors.text }]}>{cellularType}</Text>
+        ) : (
+          <MaterialCommunityIcons
+            name={cellularConnected ? 'check-circle' : 'close-circle'}
+            size={13}
+            color={cellularConnected ? colors.connected : colors.disconnected}
+          />
+        )}
       </View>
     );
   }

--- a/src/services/DeviceControlService.ts
+++ b/src/services/DeviceControlService.ts
@@ -7,7 +7,7 @@ import { NativeModules, DeviceEventEmitter } from 'react-native';
 import RNBrightness from '../utils/BrightnessModule';
 import UpdateModule from '../utils/UpdateModule';
 
-const { KioskModule } = NativeModules;
+const { KioskModule, SystemInfoModule } = NativeModules;
 
 export interface BatteryStatus {
   level: number;
@@ -48,12 +48,30 @@ export interface WifiStatus {
   connected: boolean;
 }
 
+/**
+ * Cellular state, deliberately shaped like WifiStatus.
+ *
+ * `networkType` is '' and `signalDbm` is null whenever READ_PHONE_STATE is not held,
+ * which is every Play Store build: the src/playstore overlay strips it. `connected`,
+ * `carrier` and `airplaneMode` need no permission and are always reported, so a Play
+ * build still shows whether the tablet has mobile data and whether someone put it in
+ * airplane mode.
+ */
+export interface CellularStatus {
+  connected: boolean;
+  carrier: string;
+  networkType: string;
+  signalDbm: number | null;
+  airplaneMode: boolean;
+}
+
 export interface DeviceStatus {
   battery: BatteryStatus;
   screen: ScreenStatus;
   webview: WebViewStatus;
   device: DeviceInfo;
   wifi: WifiStatus;
+  cellular: CellularStatus;
   timestamp: number;
 }
 
@@ -117,12 +135,13 @@ class DeviceControlServiceClass {
   // ==================== READ OPERATIONS ====================
 
   async getStatus(): Promise<DeviceStatus> {
-    const [battery, screen, webview, device, wifi] = await Promise.all([
+    const [battery, screen, webview, device, wifi, cellular] = await Promise.all([
       this.getBatteryStatus(),
       this.getScreenStatus(),
       this.getWebViewStatus(),
       this.getDeviceInfo(),
       this.getWifiStatus(),
+      this.getCellularStatus(),
     ]);
 
     return {
@@ -131,6 +150,7 @@ class DeviceControlServiceClass {
       webview,
       device,
       wifi,
+      cellular,
       timestamp: Math.floor(Date.now() / 1000),
     };
   }
@@ -253,6 +273,30 @@ class DeviceControlServiceClass {
       console.warn('DeviceControlService: getWifiInfo error', error);
     }
     return { ssid: '', signalStrength: 0, connected: false };
+  }
+
+  async getCellularStatus(): Promise<CellularStatus> {
+    try {
+      if (SystemInfoModule?.getCellularInfo) {
+        const info = await SystemInfoModule.getCellularInfo();
+        return {
+          connected: info.isConnected || false,
+          carrier: info.carrier || '',
+          networkType: info.networkType || '',
+          signalDbm: typeof info.signalDbm === 'number' ? info.signalDbm : null,
+          airplaneMode: info.airplaneMode || false,
+        };
+      }
+    } catch (error) {
+      console.warn('DeviceControlService: getCellularInfo error', error);
+    }
+    return {
+      connected: false,
+      carrier: '',
+      networkType: '',
+      signalDbm: null,
+      airplaneMode: false,
+    };
   }
 
   async getLocalIpAddress(): Promise<string> {

--- a/src/utils/CloudSyncService.ts
+++ b/src/utils/CloudSyncService.ts
@@ -162,6 +162,14 @@ class CloudSyncServiceClass {
             wifi_ssid: status.wifi.ssid,
             wifi_signal_dbm: status.wifi.signalStrength,
             ip_address: status.device.ip,
+            // Cellular, reported next to WiFi so a tablet on mobile data is not a
+            // blank row in the dashboard. network_type and signal_dbm are empty
+            // without READ_PHONE_STATE, which Play Store builds do not carry.
+            cellular_connected: status.cellular.connected,
+            cellular_carrier: status.cellular.carrier,
+            cellular_network_type: status.cellular.networkType,
+            cellular_signal_dbm: status.cellular.signalDbm,
+            airplane_mode: status.cellular.airplaneMode,
           },
           display: {
             screen_on: status.screen.on,


### PR DESCRIPTION
Closes #131 in part and #130 in full. Both open since 2026-04-09, both from the same beta
tester, who asked again this week.

> Would be great if you included 5g into the status bar and remote functions similar to WiFi

## What is here

**#131, the reporting half.** `SystemInfoModule` now returns a `cellular` section shaped like
its `wifi` one: connected, carrier, network generation, signal in dBm, airplane mode. The
status bar shows an item next to WiFi, and the heartbeat carries the same values so the
dashboard can display them beside the WiFi ones (cloud side in RushB-fr/freekiosk-cloud, a
separate PR).

**#130, in full.** `setAirplaneModeBlocked` applies `DISALLOW_AIRPLANE_MODE`, mirroring the
existing `setFactoryResetBlocked`. He asked for airplane mode to be *disabled at startup*;
this is better, because it stops the user reaching the toggle at all rather than undoing the
damage one reboot later, and it persists across reboots.

## READ_PHONE_STATE, and where it does not go

Declared in the main manifest, **stripped from Play Store builds** by the `src/playstore`
overlay, alongside `REQUEST_INSTALL_PACKAGES` and the others. A phone-state permission on a
kiosk browser is the kind of thing that costs a review, and it weighs on the approved-DPC
dossier too.

Only the generation and the dBm need it. `connected`, `carrier` and `airplaneMode` need
nothing, so a Play build still answers the question that actually matters: does this tablet
have mobile data.

## Three bounds, stated rather than discovered later

**Remote control of cellular is not possible**, and this does not pretend otherwise. Toggling
mobile data needs `MODIFY_PHONE_STATE`, which is system-only and unavailable to a Device Owner
as well, and cellular has no equivalent of a scan or a connect-by-SSID. Of `WifiControlModule`'s
six methods, only the read-state one has a counterpart here. Worth telling him plainly rather
than leaving "similar to WiFi" open another five months.

**5G non-standalone reads as 4G.** On NSA the data network type returns LTE because the anchor
is LTE. Catching that through `ServiceState` costs more privilege than it is worth.

**The status bar item has no dedicated toggle**, unlike battery, WiFi, bluetooth and volume. It
appears only when the device actually has cellular in play, so a WiFi-only kiosk is unchanged.
Making it configurable like the others needs a storage key, a settings control and a cloud
config field: a separate change rather than something smuggled in here. Flagging it because
#131 does say "configurable status bar", so this is partial on purpose.

## Verification

Kotlin compiles, `tsc` is clean, the Jest suite passes (6 tests, 2 suites).

**Not verified on hardware, none of it.** No tablet has run this. What needs checking: the
generation string on a real 5G SIM, the dBm value, that the status bar item looks right beside
WiFi, and that `DISALLOW_AIRPLANE_MODE` actually greys out the toggle on a Device Owner device.
