### PR TITLE
fix(webview): stop serving stale subresources from cache

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,0 +1,50 @@
+name: Build release APK
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'fix/**'
+
+jobs:
+  apk:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - uses: android-actions/setup-android@v3
+
+      - name: Install SDK packages pinned by android/build.gradle
+        run: sdkmanager "platforms;android-36" "build-tools;36.0.0" "ndk;27.1.12297006"
+
+      - name: Install JS dependencies
+        run: npm ci
+
+      - name: Build release APK
+        working-directory: android
+        run: |
+          chmod +x gradlew
+          ./gradlew assembleRelease --no-daemon --stacktrace
+
+      - name: Report APK details
+        run: |
+          ls -lh android/app/build/outputs/apk/release/
+          sha256sum android/app/build/outputs/apk/release/*.apk
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: freekiosk-release-apk
+          path: android/app/build/outputs/apk/release/*.apk
+          if-no-files-found: error

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -36,7 +36,10 @@ jobs:
         working-directory: android
         run: |
           chmod +x gradlew
-          ./gradlew assembleRelease --no-daemon --stacktrace
+          # The repo ships no android/gradle.properties, so Gradle falls back to a
+          # 512 MiB heap and the daemon dies GC-thrashing before it reaches the
+          # Kotlin compile tasks. Give it room to use the runner's 16 GB.
+          ./gradlew assembleRelease --no-daemon --stacktrace             -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=1536m"
 
       - name: Report APK details
         run: |

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -32,14 +32,27 @@ jobs:
       - name: Install JS dependencies
         run: npm ci
 
+      # android/gradle.properties is gitignored, so a fresh clone has neither the
+      # heap settings (Gradle falls back to 512 MiB and the daemon dies GC-thrashing)
+      # nor android.useAndroidX (AGP refuses the release classpath without it).
+      # Recreate the React Native defaults instead of committing an ignored file.
+      - name: Write android/gradle.properties
+        run: |
+          cat > android/gradle.properties <<'PROPS'
+          org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=1536m
+          org.gradle.parallel=true
+          android.useAndroidX=true
+          reactNativeArchitectures=armeabi-v7a,arm64-v8a
+          newArchEnabled=true
+          hermesEnabled=true
+          PROPS
+          cat android/gradle.properties
+
       - name: Build release APK
         working-directory: android
         run: |
           chmod +x gradlew
-          # The repo ships no android/gradle.properties, so Gradle falls back to a
-          # 512 MiB heap and the daemon dies GC-thrashing before it reaches the
-          # Kotlin compile tasks. Give it room to use the runner's 16 GB.
-          ./gradlew assembleRelease --no-daemon --stacktrace             -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=1536m"
+          ./gradlew assembleRelease --no-daemon --stacktrace
 
       - name: Report APK details
         run: |

--- a/src/components/WebViewComponent.tsx
+++ b/src/components/WebViewComponent.tsx
@@ -1126,8 +1126,14 @@ const WebViewComponent = forwardRef<WebViewComponentRef, WebViewComponentProps>(
         sharedCookiesEnabled={true}
         thirdPartyCookiesEnabled={true}
         
-        // Storage settings for Pinia/Nuxt compatibility
-        cacheMode="LOAD_DEFAULT"
+        // Storage settings for Pinia/Nuxt compatibility.
+        // LOAD_NO_CACHE (not LOAD_DEFAULT): kiosk pages are long-lived and reload
+        // on a timer, so a cached subresource with a generous max-age (a logo, a
+        // stylesheet) keeps being served after the site has been updated. The
+        // document revalidates on reload but its subresources do not, which shows
+        // up as a new page rendered with old assets. Always hitting the network
+        // costs bandwidth but keeps the displayed content truthful.
+        cacheMode="LOAD_NO_CACHE"
         
         // Allow popups/new windows - required for some login flows
         // Instead of opening a new window, we redirect in the same WebView


### PR DESCRIPTION
The kiosk WebView used cacheMode="LOAD_DEFAULT", so a timed reload revalidated the document but reused cached subresources that were still within their max-age. A site that had shipped a new logo therefore rendered the new page with the old image until the cache entry expired or /api/clearCache was called.

Switch to LOAD_NO_CACHE so every request goes to the network. Also add a workflow_dispatch CI job that builds the release APK and uploads it as an artifact, since the repo had no release build workflow.

## 📝 Description

Brief description of the changes in this PR.

Fixes # (issue number, if applicable)

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement

## ✅ Testing

Please describe the tests you ran to verify your changes:

- [ ] Tested on real Android device
- [ ] Tested in Device Owner mode
- [ ] Tested on multiple Android versions: ___
- [ ] No regressions found

**Device(s) tested:**
- Device: [e.g., Samsung Galaxy Tab A8]
- Android version: [e.g., Android 12]

## 📸 Screenshots/Videos

If applicable, add screenshots or videos demonstrating the changes.

## 📋 Checklist

- [ ] My code follows the project's code style
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] I have tested on a real device (not just emulator)
- [ ] All existing tests still pass

## 🔗 Related Issues/PRs

List any related issues or pull requests:
- Related to #___
- Depends on #___

## 📝 Additional Notes

Any additional information or context.
